### PR TITLE
Changing docker-compose to docker compose

### DIFF
--- a/src/setup/devnet/templates/docker/README.md
+++ b/src/setup/devnet/templates/docker/README.md
@@ -4,7 +4,7 @@
 
 ```bash
 # start heimdall0
-$ docker-compose up -d heimdall0
+$ docker compose up -d heimdall0
 
 # exec bash into heimdall0
 $ docker exec -i -t heimdall0 bash

--- a/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
@@ -6,7 +6,7 @@ for i in {0..{{ obj.totalNodes - 1 }}}
 do
   NODE_DIR=/root/.bor
   DATA_DIR=/root/.bor/data
-  docker-compose run --rm bor$i sh -c "
+  docker compose run --rm bor$i sh -c "
 bor --datadir $DATA_DIR init $NODE_DIR/genesis.json; 
 cp $NODE_DIR/nodekey $DATA_DIR/bor/;
 cp $NODE_DIR/static-nodes.json $DATA_DIR/bor/;

--- a/src/setup/devnet/templates/docker/docker-bor-start.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-start.sh.njk
@@ -15,7 +15,7 @@ ADDRESS=${ADDRESSES[$INDEX]};
 NODE_DIR=/root/.bor
 DATA_DIR=/root/.bor/data
 
-docker-compose run --service-ports -d --name bor$INDEX bor$INDEX sh -c "
+docker compose run --service-ports -d --name bor$INDEX bor$INDEX sh -c "
 touch /root/logs/bor.log
 bor --datadir $DATA_DIR \
   --port 30303 \

--- a/src/setup/devnet/templates/docker/docker-clean.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-clean.sh.njk
@@ -7,7 +7,7 @@ PRIV_VALIDATOR_STATE="{
 }"
 
 # stop and remove docker containers
-docker-compose down
+docker compose down
 
 # clean repo
 for i in {0..{{ obj.totalNodes - 1 }}}

--- a/src/setup/devnet/templates/docker/docker-ganache-start.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-ganache-start.sh.njk
@@ -4,7 +4,7 @@ set -x #echo on
 
 DATA_DIR={{ ganache.dbName }}
 
-docker-compose run --rm --service-ports --name ganache ganache --hardfork istanbul \
+docker compose run --rm --service-ports --name ganache ganache --hardfork istanbul \
   --blockTime 1 \
   --db /root/data/$DATA_DIR \
   {% for acc in obj.config.accounts %}--account {{ acc.privateKey }},1000000000000000000000 {% endfor %}\

--- a/src/setup/devnet/templates/docker/docker-heimdall-start.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-heimdall-start.sh.njk
@@ -2,7 +2,7 @@
 
 INDEX=$1
 
-docker-compose run -d --service-ports --name heimdall$INDEX heimdall$INDEX bash -c "
+docker compose run -d --service-ports --name heimdall$INDEX heimdall$INDEX bash -c "
 touch /root/heimdall/logs/heimdalld.log & touch /root/heimdall/logs/bridge.log & touch /root/heimdall/logs/heimdalld-rest-server.log &
 heimdalld start > /root/heimdall/logs/heimdalld.log 2>&1 &
 heimdalld rest-server > /root/heimdall/logs/heimdalld-rest-server.log 2>&1 &


### PR DESCRIPTION
Latest versions of docker switched to having `compose` as a plugin, and so it now gets invoked via `docker compose`: https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command