### PR TITLE
setup: add miner.etherbase

### DIFF
--- a/src/setup/devnet/templates/docker/docker-bor-start.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-start.sh.njk
@@ -39,6 +39,7 @@ bor server \
   --txpool.globalslots '20000' \
   --txpool.lifetime '0h16m0s' \
   --unlock $ADDRESS \
+  --miner.etherbase $ADDRESS \
   --keystore $NODE_DIR/keystore \
   --password $NODE_DIR/password.txt \
   --allow-insecure-unlock \


### PR DESCRIPTION
This PR adds the `miner.etherbase` flag in docker start.sh. This is necessary due to the disabling of personal wallet endpoints in new-cli of bor.