### PR TITLE
add: dev: default ethHostUser / run ganache detached / gitignore idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 test
 .DS_Store
 devnet
+.idea

--- a/configs/devnet/docker-setup-config.yaml
+++ b/configs/devnet/docker-setup-config.yaml
@@ -9,3 +9,4 @@ numOfValidators: 2
 numOfNonValidators: 0
 ethURL: http://ganache:9545
 devnetType: docker
+ethHostUser: ubuntu

--- a/src/setup/devnet/templates/docker/docker-ganache-start.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-ganache-start.sh.njk
@@ -4,10 +4,10 @@ set -x #echo on
 
 DATA_DIR={{ ganache.dbName }}
 
-docker compose run --rm --service-ports --name ganache ganache --hardfork istanbul \
+docker compose run -d --rm --service-ports --name ganache ganache --hardfork istanbul \
   --blockTime 1 \
   --db /root/data/$DATA_DIR \
   {% for acc in obj.config.accounts %}--account {{ acc.privateKey }},1000000000000000000000 {% endfor %}\
   --gasLimit 8000000 \
   --gasPrice 0 \
-  -p 9545 -h 0.0.0.0 
+  -p 9545 -h 0.0.0.0


### PR DESCRIPTION
This - small - PR introduces the following changes: 
- run `ganache` in a detached way when using docker setup
- dafault the `ethHostUser`, as this field is mandatory in the interactive setup, otherwise it won't proceed
- `gitignore` idea IDE related files