### PR TITLE
mardizzone/pos-895

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 # terraform variables
 TF_VAR_VM_NAME=YOUR_IDENTIFIER # default "polygon-user". It can be any string, used to discriminate between instances
-TF_VAR_DOCKERIZED=no # if set to 'yes', only one VM will be created and the network will run in a dockerized stack
 TF_VAR_DISK_SIZE_GB=500 # size of the disk in GB
 TF_VAR_ACCESS_KEY=YOUR_AWS_ACCESS_KEY
 TF_VAR_SECRET_KEY=YOUR_AWS_SECRET_KEY

--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ To use the `express-cli` you have to execute the following steps.
 - generate a keypair on AWS EC2 and download its certificate locally (`.pem` or `.cer` file)
 - copy `.env.example` to `.env` with command `cp .env.example .env`
 - replace `TF_VAR_ACCESS_KEY` and `TF_VAR_SECRET_KEY` with your own keys (ask devops to generate one for you)
+- set at least 2 nodes (`TF_VAR_VALIDATOR_COUNT` + `TF_VAR_SENTRY_COUNT` > 1) and adjust the `DEVNET_BOR_USERS` accordingly 
 - (optional) replace `TF_VAR_VM_NAME` with your own identifier (it can be any string, default is "polygon-user")
 - (optional) replace `TF_VAR_DISK_SIZE_GB` with your preferred disk size in GB (default is 500 GB)
 - `VERBOSE=true` prints logs from the remote machines. If set to `false`, only `express-cli` and `matic-cli` logs will be shown
-- set `TF_VAR_DOCKERIZED` to `no`. Option `yes` runs the network on one VM only in a dockerized stack, but it's still a WIP (see POS-848)
 - make sure `PEM_FILE_PATH` points to a correct AWS key certificate, the one you downloaded in the previous step
 - (optional) source the `.env` file if your local system requires to, with command `source .env`  
 - see other details of `.env` vars in the `.env.example` template
@@ -169,6 +169,7 @@ First off, you need to `--init` terraform on your local machine, by executing th
 Then, a remote devnet can be created with the `--start` command, as follows.
 - `./bin/express-cli --start` 
   - Creates the desired remote setup, based on the preferences defined in the `.env` file
+  - `--start` command can be used also to target an existing AWS setup. If changes to `.env` file are detected, the previous devnet will be destroyed and a new one created, reusing the same AWS VMs  
 To destroy the remote devnet, you can execute the `--destroy` command.
 - `./bin/express-cli --destroy`
   - Destroys the remote setup and delete the dedicated VMs

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 resource "aws_instance" "app_server" {
-  count = (var.DOCKERIZED == "yes") ? 1 : (var.VALIDATOR_COUNT + var.SENTRY_COUNT)
+  count = var.VALIDATOR_COUNT + var.SENTRY_COUNT
   ami                    = var.INSTANCE_AMI
   instance_type          = var.INSTANCE_TYPE
   key_name               = var.PEM_FILE

--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -45,6 +45,8 @@ export async function cli() {
 
     else if (options.start) {
         console.log("📍Command --start");
+        console.log("⛔ If you are targeting an already existing devnet, this comand will only work if all bor ipc sessions have been manually closed...")
+        await timer(3000)
         await start();
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,10 +11,6 @@ variable "VM_NAME" {
   default = "polygon-user"
 }
 
-variable "DOCKERIZED" {
-  default = "no"
-}
-
 variable "DISK_SIZE_GB" {
   default = "500"
 }


### PR DESCRIPTION
This PR implements JIRA issue https://polygon.atlassian.net/browse/POS-895
It gives the opportunity to re-use the `--start` command to target an existing AWS setup and relaunch the devnet according to the latest `.env` changes.
In this way, the VMs from the previous devnet are reused instead of being destroyed every time. 
This also saves time when deploying the new setup, as the previously existing machines already come with installed requirements.  

Also, support for docker has been removed as the relative task got canceled. 