### PR TITLE
Mardizzone/docker rmi

### DIFF
--- a/src/express/common/config-utils.js
+++ b/src/express/common/config-utils.js
@@ -58,8 +58,8 @@ export function setCommonConfigs(doc) {
     setConfigValue('numOfValidators', parseInt(process.env.TF_VAR_VALIDATOR_COUNT), doc);
     setConfigValue('numOfNonValidators', parseInt(process.env.TF_VAR_SENTRY_COUNT), doc);
     setConfigValue('ethHostUser', process.env.ETH_HOST_USER, doc);
-    setConfigValue('borDockerBuildContext', process.env.BOR_DOCKER_BUILD_CONTENXT, doc);
-    setConfigValue('heimdallDockerBuildContext', process.env.HEIMDALL_DOCKER_BUILD_CONTENXT, doc);
+    setConfigValue('borDockerBuildContext', process.env.BOR_DOCKER_BUILD_CONTEXT, doc);
+    setConfigValue('heimdallDockerBuildContext', process.env.HEIMDALL_DOCKER_BUILD_CONTEXT, doc);
 }
 
 export function setConfigValue(key, value, doc) {

--- a/src/setup/devnet/templates/docker/docker-clean.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-clean.sh.njk
@@ -6,8 +6,8 @@ PRIV_VALIDATOR_STATE="{
   \"step\": 0
 }"
 
-# stop and remove docker containers
-docker compose down
+# stop and remove docker containers and images
+docker compose down --rmi all
 
 # clean repo
 for i in {0..{{ obj.totalNodes - 1 }}}


### PR DESCRIPTION
# Description

Remove docker images when running `docker compose down`. Pulling fresh images without re-using cached ones will provides `matic-cli` with the opportunity to change branches for `bor` or `heimdall` on the go and avoid manual steps.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
