### PR TITLE
fix : rm multiple keystore docker

### DIFF
--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -380,25 +380,6 @@ export class Devnet {
                 },
             },
             {
-                title: "Remove multiple keystore files",
-                task: async() => {
-                    for (let i = 0; i < this.totalNodes; i++) {
-                        // remove multiple keystore files from node[i]/bor/keystore
-                        let keystoreDir = path.join(this.testnetDir,`node${i}`,"bor", "keystore");
-                        fs.readdir(keystoreDir, async (err, files) => {
-                            if (err) throw err;
-
-                            for(var j=1; j<files.length; j++) {
-                                await fs.unlink(path.join(keystoreDir, files[j]), err => {
-                                    if (err) throw err;
-                                });
-                            }
-                        });
-                        await timer(2000);
-                    }
-                }
-            },
-            {
                 title: "Copy files to remote servers",
                 task: async () => {
                     if (this.config.devnetBorHosts === undefined) {
@@ -723,6 +704,28 @@ export class Devnet {
                 title: ganache.taskTitle,
                 task: () => {
                     return ganache.getTasks();
+                },
+                enabled: () => {
+                    return this.config.devnetType === "docker" || "remote";
+                },
+            },
+            {
+                title: "Remove multiple keystore files",
+                task: async() => {
+                    for (let i = 0; i < this.totalNodes; i++) {
+                        // remove multiple keystore files from node[i]/bor/keystore
+                        let keystoreDir = path.join(this.testnetDir,`node${i}`,"bor", "keystore");
+                        fs.readdir(keystoreDir, async (err, files) => {
+                            if (err) throw err;
+
+                            for(var j=1; j<files.length; j++) {
+                                await fs.unlink(path.join(keystoreDir, files[j]), err => {
+                                    if (err) throw err;
+                                });
+                            }
+                        });
+                        await timer(2000);
+                    }
                 },
                 enabled: () => {
                     return this.config.devnetType === "docker" || "remote";


### PR DESCRIPTION
In this PR, we make the codeblock for removing multiple keystore files common to both remote and docker setups. 