### PR TITLE
Devnet-Datadog Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ DEVNET_BOR_USERS=ubuntu,ubuntu,ubuntu #users' names of VMs for all the nodes (co
 BOR_DOCKER_BUILD_CONTEXT="https://github.com/maticnetwork/bor.git#c5569e4da9ebe0ce4e63aec571966c71234f7cfc" # todo change to develop once https://polygon.atlassian.net/browse/POS-979 is solved (docker build context for bor. Used in docker setup (TF_VAR_DOCKERIZED=yes))
 HEIMDALL_DOCKER_BUILD_CONTEXT="https://github.com/maticnetwork/heimdall.git#develop" # docker build context for heimdall. Used in docker setup (TF_VAR_DOCKERIZED=yes)
 VERBOSE=true # if set to true will print logs also from remote machines
+DD_API_KEY=<DATADOG API KEY> # Datadog API key
 
 #Stress test variables (used to run stress tests against the remote nodes)
 MNEMONIC="clock radar mass judge dismiss just intact mind resemble fringe diary casino" #random mnemonic

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules
 test
 .DS_Store
-devnet
 .env
 .terraform*
 terraform.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 test
 .DS_Store
+devnet
 .env
 .terraform*
 terraform.tfstate

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ First off, you need to `--init` terraform on your local machine, by executing th
 - `./bin/express-cli --stress [fund]`
     - Runs the stress tests on remote nodes. The string `fund` is needed when stress tests are ran for the first time,
       to fund the accounts
+- `./bin/express-cli --setup-datadog`
+    - Sets up datadog on the nodes and gets them ready to send metrics to Datadog Dashboard. `DD_API_KEY` env var is required for this.
 
 
 ## `matic-cli`

--- a/configs/README.md
+++ b/configs/README.md
@@ -87,4 +87,7 @@ borDockerBuildContext: "https://github.com/maticnetwork/bor.git#c5569e4da9ebe0ce
 # Docker build context for heimdall. Used in docker setup. When specified, heimdallBranch will be ignored.
 heimdallDockerBuildContext: "https://github.com/maticnetwork/heimdall.git#develop"
 
+# Datadog api key required to setup datadog traces and metrics for the node.
+DD_API_KEY: <DATADOG API KEY> # Datadog API key
+
 ```

--- a/configs/devnet/openmetrics-conf.yaml
+++ b/configs/devnet/openmetrics-conf.yaml
@@ -1,0 +1,25 @@
+instances:
+-   metrics:
+    - geth*
+    - txpool*
+    - trie*
+    - system*
+    - state*
+    - rpc*
+    - p2p*
+    - les*
+    - eth*
+    - chain*
+    namespace: bor
+    openmetrics_endpoint: http://localhost:7071/debug/metrics/prometheus
+-   exclude_metrics:
+    - tendermint_p2p_peer_receive_bytes*
+    - tendermint_p2p_peer_send_bytes*
+    - tendermint_p2p_peer_pending_send_bytes*
+    metrics:
+    - tendermint_mempool*
+    - tendermint_consensus*
+    - process*
+    - go*
+    namespace: heimdalld
+    openmetrics_endpoint: http://localhost:26660/metrics

--- a/configs/devnet/otel-config-dd.yaml
+++ b/configs/devnet/otel-config-dd.yaml
@@ -1,0 +1,58 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+  hostmetrics:
+    collection_interval: 10s
+    scrapers:
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: true
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+      disk: null
+      filesystem:
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
+      load: null
+      memory: null
+      network: null
+      processes: null
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: otelcol
+          scrape_interval: 10s
+          static_configs:
+            - targets:
+                - 0.0.0.0:8888
+processors:
+  batch:
+    timeout: 10s
+exporters:
+  datadog:
+    api:
+      key: ${DD_API_KEY}
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - hostmetrics
+        - otlp
+        - prometheus
+      processors:
+        - batch
+      exporters:
+        - datadog
+    traces:
+      receivers:
+        - otlp
+      processors:
+        - batch
+      exporters:
+        - datadog

--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -7,6 +7,7 @@ import { sendStateSyncTx } from "./express/commands/send-state-sync";
 import { monitor } from "./express/commands/monitor";
 import { restartAll, restartBor, restartHeimdall } from "./express/commands/restart";
 import { cleanup } from "./express/commands/cleanup";
+import { setupDatadog } from "./express/commands/setup-datadog";
 import { program } from "commander";
 import pkg from "../package.json";
 
@@ -28,6 +29,7 @@ program
     .option('-m, --monitor', 'Monitor the setup')
     .option('-t, --stress [fund]', 'Start the stress test. If the string `fund` is specified, the account will be funded. This option is mandatory when the command is executed the first time on a devnet.')
     .option('-ss, --send-state-sync', 'Send state sync tx')
+    .option('-dd, --setup-datadog', 'Setup DataDog')
     .version(pkg.version);
 
 
@@ -129,6 +131,12 @@ export async function cli() {
         console.log("📍Command --send-state-sync");
         await timer(3000)
         await sendStateSyncTx();
+    }
+
+    else if (options.setupDatadog) {
+        console.log("📍Command --setup-datadog");
+        await timer(3000)
+        await setupDatadog();
     }
 }
 

--- a/src/express/commands/setup-datadog.js
+++ b/src/express/commands/setup-datadog.js
@@ -49,7 +49,14 @@ export async function setupDatadog() {
         console.log("📍Monitoring the node", host);
 
         var apiKey = process.env.DD_API_KEY
-        let command = `DD_API_KEY=${apiKey} DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
+        var envName = process.env.TF_VAR_VM_NAME
+        if(envName === undefined) {
+            let x = parseInt(Math.random() * 1000000);
+            envName = `devnet-${x}`
+        }
+
+        console.log("📍Setting up datadog for", envName);
+        let command = `DD_API_KEY=${apiKey} DD_SITE="datadoghq.com" DD_HOST_TAGS="env:${envName}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
         await runSshCommand(`${user}@${host}`, command, maxRetries)
         console.log(`📍Datadog installed on ${host}`)
 
@@ -80,5 +87,7 @@ export async function setupDatadog() {
         // revert dd api key
         setDatadogAPIKey('${DD_API_KEY}', dd_doc)
     }
+
+    console.log("📍Datadog setup complete");
 
 }

--- a/src/express/commands/setup-datadog.js
+++ b/src/express/commands/setup-datadog.js
@@ -41,6 +41,7 @@ export async function setupDatadog() {
 
 
     let borUsers = splitToArray(doc['devnetBorUsers'].toString())
+    var envName
 
     for(let i = 0; i < doc['devnetBorHosts'].length ; i++) {
         var host = doc['devnetBorHosts'][i]
@@ -49,7 +50,7 @@ export async function setupDatadog() {
         console.log("📍Monitoring the node", host);
 
         var apiKey = process.env.DD_API_KEY
-        var envName = process.env.TF_VAR_VM_NAME
+        envName = process.env.TF_VAR_VM_NAME
         if(envName === undefined) {
             let x = parseInt(Math.random() * 1000000);
             envName = `devnet-${x}`
@@ -88,6 +89,7 @@ export async function setupDatadog() {
         setDatadogAPIKey('${DD_API_KEY}', dd_doc)
     }
 
+    console.log("📍Datadog devnet env : ", envName)
     console.log("📍Datadog setup complete");
 
 }

--- a/src/express/commands/setup-datadog.js
+++ b/src/express/commands/setup-datadog.js
@@ -1,0 +1,84 @@
+const yaml = require("js-yaml");
+const fs = require("fs");
+const {runScpCommand, runSshCommand, maxRetries} = require("../common/remote-worker");
+const {installDocker} = require("./start.js")
+import {splitToArray} from "../common/config-utils";
+
+const timer = ms => new Promise(res => setTimeout(res, ms))
+
+export async function setDatadogAPIKey(value, doc) {
+    if (value !== undefined) {
+        doc['exporters']['datadog']['api']['key'] = value;
+    }
+
+    fs.writeFile('./configs/devnet/otel-config-dd.yaml', yaml.dump(doc), (err) => {
+        if (err) {
+            console.log("❌ Error while writing datadog YAML configs: \n", err)
+            process.exit(1)
+        }
+    });
+
+    await timer(1000)
+}
+
+export async function setupDatadog() {
+
+    let doc
+
+    if (process.env.TF_VAR_DOCKERIZED === 'yes') {
+        console.log("Not supported for datadog at the moment")
+        return
+    } else {
+        doc = await yaml.load(fs.readFileSync('./configs/devnet/remote-setup-config.yaml', 'utf8'));
+    }
+
+    if (doc['devnetBorHosts'].length > 0) {
+        console.log("📍Monitoring the nodes", doc['devnetBorHosts'][0]);
+    } else {
+        console.log("📍No nodes to monitor, please check your configs! Exiting...");
+        process.exit(1)
+    }
+
+
+    let borUsers = splitToArray(doc['devnetBorUsers'].toString())
+
+    for(let i = 0; i < doc['devnetBorHosts'].length ; i++) {
+        var host = doc['devnetBorHosts'][i]
+        var user = borUsers[i]
+
+        console.log("📍Monitoring the node", host);
+
+        var apiKey = process.env.DD_API_KEY
+        let command = `DD_API_KEY=${apiKey} DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
+        await runSshCommand(`${user}@${host}`, command, maxRetries)
+        console.log(`📍Datadog installed on ${host}`)
+
+        await installDocker(`${user}@${host}`, user)
+        console.log(`📍Docker installed`)
+
+        let dd_doc = await yaml.load(fs.readFileSync('./configs/devnet/otel-config-dd.yaml', 'utf8'), undefined);
+        setDatadogAPIKey(apiKey, dd_doc)
+
+        let src = `./configs/devnet/otel-config-dd.yaml`
+        let dest = `${user}@${host}:~/otel-config-dd.yaml`
+        await runScpCommand(src, dest, maxRetries)
+
+        src = `./configs/devnet/openmetrics-conf.yaml`
+        dest = `${user}@${host}:~/conf.yaml`
+        await runScpCommand(src, dest, maxRetries)
+
+        command = `sudo mv ~/conf.yaml /etc/datadog-agent/conf.d/openmetrics.d/conf.yaml`
+        await runSshCommand(`${user}@${host}`, command, maxRetries)
+
+        command = `sudo docker run -d --net=host -v ~/otel-config-dd.yaml:/otel-local-config.yaml otel/opentelemetry-collector-contrib --config otel-local-config.yaml`
+        await runSshCommand(`${user}@${host}`, command, maxRetries)
+        console.log(`📍OpenCollector started on ${host}`)
+
+        command = `sudo service datadog-agent restart`
+        await runSshCommand(`${user}@${host}`, command, maxRetries)
+
+        // revert dd api key
+        setDatadogAPIKey('${DD_API_KEY}', dd_doc)
+    }
+
+}

--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -143,7 +143,7 @@ async function installHostSpecificPackages(ip) {
     await runSshCommand(ip, command, maxRetries)
 }
 
-async function installDocker(ip, user) {
+export async function installDocker(ip, user) {
 
     console.log("📍Setting docker repository up...")
     let command = `sudo apt-get update -y && sudo apt install apt-transport-https ca-certificates curl software-properties-common -y`

--- a/src/setup/devnet/templates/remote/bor/bor-start.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-start.sh.njk
@@ -29,7 +29,8 @@ bor server \
   --txpool.globalslots '20000'  \
   --txpool.lifetime '0h16m0s' \
   --maxpeers 200 \
-  --metrics \
+  --metrics --metrics.expensive \
+  --metrics.opencollector-endpoint="127.0.0.1:4317" \
   --unlock $ADDRESS \
   --miner.etherbase $ADDRESS \
   --keystore $BOR_HOME/keystore \


### PR DESCRIPTION
In this PR, we add the feature to setup Datadog integration of devnet nodes. The traces and metrics from a node will be also now available on the Datadog dashboard. 

For setting up datadog, a user can use `./bin/express-cli --setup-datadog`. This will initialise the setup on the machines. To use this feature, the user must specify `DD_API_KEY` in `.env` file. 