### PR TITLE
Temporary fix: add appropriate error log while executing init command

### DIFF
--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -45,7 +45,7 @@ export async function cli() {
     if (options.init) {
         console.log("📍Command --init");
         if (!checkDir(true)) {
-            console.log("❌ The command is supposed to be executed from the project root!");
+            console.log("❌ The init command is supposed to be executed from the project root directory, named 'matic-cli'!");
             process.exit(1)
         }
         await terraformInit();


### PR DESCRIPTION
# Description

This PR modifies the error log with an appropriate message while executing the `init` command from the project root not named `matic-cli`

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
