### PR TITLE
Update Listr dependency and parallelize tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "ganache": "^7.5.0",
         "inquirer": "^6.2.2",
         "js-yaml": "^4.1.0",
-        "listr2": "^5.0.6",
+        "listr2": "^4.0.5",
         "node-fetch": "^2.6.7",
         "nunjucks": "^3.2.1",
         "pkg-install": "^1.0.0",
@@ -7516,21 +7516,21 @@
       }
     },
     "node_modules/listr2": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.6.tgz",
-      "integrity": "sha512-u60KxKBy1BR2uLJNTWNptzWQ1ob/gjMzIJPZffAENzpZqbMZ/5PrXXOomDcevIS/+IB7s1mmCEtSlT2qHWMqag==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
       "dependencies": {
         "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.19",
+        "colorette": "^2.0.16",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.7",
+        "rxjs": "^7.5.5",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=12"
       },
       "peerDependencies": {
         "enquirer": ">= 2.3.0 < 3"
@@ -16500,16 +16500,16 @@
       }
     },
     "listr2": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.6.tgz",
-      "integrity": "sha512-u60KxKBy1BR2uLJNTWNptzWQ1ob/gjMzIJPZffAENzpZqbMZ/5PrXXOomDcevIS/+IB7s1mmCEtSlT2qHWMqag==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
       "requires": {
         "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.19",
+        "colorette": "^2.0.16",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.7",
+        "rxjs": "^7.5.5",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "ganache": "^7.5.0",
         "inquirer": "^6.2.2",
         "js-yaml": "^4.1.0",
-        "listr": "^0.14.3",
+        "listr2": "^5.0.6",
         "node-fetch": "^2.6.7",
         "nunjucks": "^3.2.1",
         "pkg-install": "^1.0.0",
@@ -1464,25 +1464,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@samverschueren/stream-to-observable": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
-      "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
-      "dependencies": {
-        "any-observable": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependenciesMeta": {
-        "rxjs": {
-          "optional": true
-        },
-        "zen-observable": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@scure/base": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
@@ -2420,6 +2401,26 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aggregate-error/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2481,14 +2482,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/any-observable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/any-promise": {
@@ -2578,6 +2571,14 @@
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/async": {
@@ -3379,6 +3380,14 @@
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
@@ -3399,61 +3408,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-      "integrity": "sha512-f4r4yJnbT++qUPI9NR4XLDLq41gQ+uqnPItWG0F5ZkehuNiTTa3EY0S4AqTSUOeJ7/zU41oWPQSNkW5BqPL9bg==",
-      "dependencies": {
-        "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/cli-width": {
@@ -3480,19 +3434,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3503,8 +3448,12 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/colorette": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3742,11 +3691,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3982,14 +3926,6 @@
       "version": "1.4.251",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
       "integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ=="
-    },
-    "node_modules/elegant-spinner": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -6646,25 +6582,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -6887,14 +6804,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/inflight": {
@@ -7188,17 +7097,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-      "dependencies": {
-        "symbol-observable": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -7207,11 +7105,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -7622,136 +7515,244 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/listr": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+    "node_modules/listr2": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.6.tgz",
+      "integrity": "sha512-u60KxKBy1BR2uLJNTWNptzWQ1ob/gjMzIJPZffAENzpZqbMZ/5PrXXOomDcevIS/+IB7s1mmCEtSlT2qHWMqag==",
       "dependencies": {
-        "@samverschueren/stream-to-observable": "^0.3.0",
-        "is-observable": "^1.1.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.5.0",
-        "listr-verbose-renderer": "^0.5.0",
-        "p-map": "^2.0.0",
-        "rxjs": "^6.3.3"
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.19",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.7",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/listr-silent-renderer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/listr-update-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-      "dependencies": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^2.3.0",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": "^14.13.1 || >=16.0.0"
       },
       "peerDependencies": {
-        "listr": "^0.14.2"
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
       }
     },
-    "node_modules/listr-update-renderer/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/listr-update-renderer/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/listr-update-renderer/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+    "node_modules/listr2/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "type-fest": "^0.21.3"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/listr-update-renderer/node_modules/figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/listr-update-renderer/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+    "node_modules/listr2/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dependencies": {
-        "ansi-regex": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
-    "node_modules/listr-update-renderer/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/listr-verbose-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+    "node_modules/listr2/node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
       "dependencies": {
-        "chalk": "^2.4.1",
-        "cli-cursor": "^2.1.0",
-        "date-fns": "^1.27.2",
-        "figures": "^2.0.0"
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/listr/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+    "node_modules/listr2/node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/log-update/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/listr2/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/rxjs": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/listr2/node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/listr2/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/locate-path": {
@@ -7782,80 +7783,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dependencies": {
-        "chalk": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/log-update": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
-      "dependencies": {
-        "ansi-escapes": "^3.0.0",
-        "cli-cursor": "^2.0.0",
-        "wrap-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
@@ -8320,14 +8247,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/number-to-bn": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
@@ -8537,14 +8456,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/p-try": {
@@ -9071,6 +8982,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -9406,14 +9322,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/sshpk": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
@@ -9722,14 +9630,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/tar": {
@@ -10709,57 +10609,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-      "dependencies": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/wrappy": {
@@ -11826,14 +11675,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@samverschueren/stream-to-observable": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
-      "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
-      "requires": {
-        "any-observable": "^0.3.0"
-      }
-    },
     "@scure/base": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
@@ -12638,6 +12479,22 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+        }
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -12683,11 +12540,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.1.tgz",
       "integrity": "sha512-qDOv24WjnYuL+wbwHdlsYZFy+cgPtrYw0Tn7GLORicQp9BkQLzrgI3Pm4VyR9ERZ41YTn7KlMPuL1n05WdZvmg=="
-    },
-    "any-observable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
     },
     "any-promise": {
       "version": "1.3.0",
@@ -12764,6 +12616,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async": {
       "version": "2.6.4",
@@ -13389,6 +13246,11 @@
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+    },
     "cli-boxes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
@@ -13400,48 +13262,6 @@
       "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
       "requires": {
         "restore-cursor": "^2.0.0"
-      }
-    },
-    "cli-truncate": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-      "integrity": "sha512-f4r4yJnbT++qUPI9NR4XLDLq41gQ+uqnPItWG0F5ZkehuNiTTa3EY0S4AqTSUOeJ7/zU41oWPQSNkW5BqPL9bg==",
-      "requires": {
-        "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
       }
     },
     "cli-width": {
@@ -13462,16 +13282,10 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -13479,8 +13293,12 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "colorette": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -13677,11 +13495,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -13873,11 +13686,6 @@
       "version": "1.4.251",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
       "integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ=="
-    },
-    "elegant-spinner": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -15986,21 +15794,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
-        }
-      }
-    },
     "has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -16157,11 +15950,6 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
-    },
-    "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
     },
     "inflight": {
       "version": "1.0.6",
@@ -16366,24 +16154,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-      "requires": {
-        "symbol-observable": "^1.1.0"
-      }
-    },
     "is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -16724,104 +16499,165 @@
         "type-check": "~0.4.0"
       }
     },
-    "listr": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+    "listr2": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.6.tgz",
+      "integrity": "sha512-u60KxKBy1BR2uLJNTWNptzWQ1ob/gjMzIJPZffAENzpZqbMZ/5PrXXOomDcevIS/+IB7s1mmCEtSlT2qHWMqag==",
       "requires": {
-        "@samverschueren/stream-to-observable": "^0.3.0",
-        "is-observable": "^1.1.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.5.0",
-        "listr-verbose-renderer": "^0.5.0",
-        "p-map": "^2.0.0",
-        "rxjs": "^6.3.3"
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.19",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.7",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        }
-      }
-    },
-    "listr-silent-renderer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
-    },
-    "listr-update-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-      "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^2.3.0",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
         },
         "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "color-convert": "^2.0.1"
           }
         },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "restore-cursor": "^3.1.0"
           }
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+        "cli-truncate": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "slice-ansi": "^3.0.0",
+            "string-width": "^4.2.0"
           }
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        "log-update": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+          "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+          "requires": {
+            "ansi-escapes": "^4.3.0",
+            "cli-cursor": "^3.1.0",
+            "slice-ansi": "^4.0.0",
+            "wrap-ansi": "^6.2.0"
+          },
+          "dependencies": {
+            "slice-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+              "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+              "requires": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+              }
+            },
+            "wrap-ansi": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+              "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+              "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+              }
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "rxjs": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+          "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
         }
-      }
-    },
-    "listr-verbose-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-      "requires": {
-        "chalk": "^2.4.1",
-        "cli-cursor": "^2.1.0",
-        "date-fns": "^1.27.2",
-        "figures": "^2.0.0"
       }
     },
     "locate-path": {
@@ -16849,61 +16685,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "requires": {
-        "chalk": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "log-update": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
-      "requires": {
-        "ansi-escapes": "^3.0.0",
-        "cli-cursor": "^2.0.0",
-        "wrap-ansi": "^3.0.1"
-      }
     },
     "lowercase-keys": {
       "version": "3.0.0",
@@ -17302,11 +17083,6 @@
         "path-key": "^2.0.0"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
     "number-to-bn": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
@@ -17453,11 +17229,6 @@
       "requires": {
         "p-limit": "^1.1.0"
       }
-    },
-    "p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-try": {
       "version": "1.0.0",
@@ -17851,6 +17622,11 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -18089,11 +17865,6 @@
         }
       }
     },
-    "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
-    },
     "sshpk": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
@@ -18317,11 +18088,6 @@
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "tar": {
       "version": "4.4.19",
@@ -19138,44 +18904,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
-    },
-    "wrap-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-      "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ganache": "^7.5.0",
     "inquirer": "^6.2.2",
     "js-yaml": "^4.1.0",
-    "listr2": "^5.0.6",
+    "listr2": "^4.0.5",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.1",
     "pkg-install": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ganache": "^7.5.0",
     "inquirer": "^6.2.2",
     "js-yaml": "^4.1.0",
-    "listr": "^0.14.3",
+    "listr2": "^5.0.6",
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.1",
     "pkg-install": "^1.0.0",

--- a/src/express/common/config-utils.js
+++ b/src/express/common/config-utils.js
@@ -152,17 +152,24 @@ function validateUsersAndHosts() {
   const valCount = Number(process.env.TF_VAR_VALIDATOR_COUNT)
   const senCount = Number(process.env.TF_VAR_SENTRY_COUNT)
   const archiveCount = Number(process.env.TF_VAR_ARCHIVE_COUNT)
-  if (
-    borUsers.length !== borHosts.length ||
-    borUsers.length !== valCount + senCount + archiveCount ||
-    borHosts.length !== valCount + senCount + archiveCount
-  ) {
+  if (process.env.TF_VAR_DOCKERIZED === "yes" && borUsers.length !== valCount + senCount + archiveCount) {
     console.log(
-      '❌ DEVNET_BOR_USERS or DEVNET_BOR_HOSTS lengths are not equal to the nodes count ' +
+      '❌ DEVNET_BOR_USERS lengths are not equal to the nodes count ' +
         '(TF_VAR_VALIDATOR_COUNT+TF_VAR_SENTRY_COUNT+TF_VAR_ARCHIVE_COUNT), please check your configs!'
     )
     process.exit(1)
+  } else if((process.env.TF_VAR_DOCKERIZED === "no") &&
+    (borUsers.length !== borHosts.length ||
+    borUsers.length !== valCount + senCount + archiveCount ||
+    borHosts.length !== valCount + senCount + archiveCount)
+  ) {
+      console.log(
+        '❌ DEVNET_BOR_USERS or DEVNET_BOR_HOSTS lengths are not equal to the nodes count ' +
+          '(TF_VAR_VALIDATOR_COUNT+TF_VAR_SENTRY_COUNT+TF_VAR_ARCHIVE_COUNT), please check your configs!'
+      )
+      process.exit(1)
   }
+  
   borUsers.forEach((user) => {
     if (user !== 'ubuntu') {
       console.log(

--- a/src/express/common/config-utils.js
+++ b/src/express/common/config-utils.js
@@ -152,24 +152,28 @@ function validateUsersAndHosts() {
   const valCount = Number(process.env.TF_VAR_VALIDATOR_COUNT)
   const senCount = Number(process.env.TF_VAR_SENTRY_COUNT)
   const archiveCount = Number(process.env.TF_VAR_ARCHIVE_COUNT)
-  if (process.env.TF_VAR_DOCKERIZED === "yes" && borUsers.length !== valCount + senCount + archiveCount) {
+  if (
+    process.env.TF_VAR_DOCKERIZED === 'yes' &&
+    borUsers.length !== valCount + senCount + archiveCount
+  ) {
     console.log(
       '❌ DEVNET_BOR_USERS lengths are not equal to the nodes count ' +
         '(TF_VAR_VALIDATOR_COUNT+TF_VAR_SENTRY_COUNT+TF_VAR_ARCHIVE_COUNT), please check your configs!'
     )
     process.exit(1)
-  } else if((process.env.TF_VAR_DOCKERIZED === "no") &&
+  } else if (
+    process.env.TF_VAR_DOCKERIZED === 'no' &&
     (borUsers.length !== borHosts.length ||
-    borUsers.length !== valCount + senCount + archiveCount ||
-    borHosts.length !== valCount + senCount + archiveCount)
+      borUsers.length !== valCount + senCount + archiveCount ||
+      borHosts.length !== valCount + senCount + archiveCount)
   ) {
-      console.log(
-        '❌ DEVNET_BOR_USERS or DEVNET_BOR_HOSTS lengths are not equal to the nodes count ' +
-          '(TF_VAR_VALIDATOR_COUNT+TF_VAR_SENTRY_COUNT+TF_VAR_ARCHIVE_COUNT), please check your configs!'
-      )
-      process.exit(1)
+    console.log(
+      '❌ DEVNET_BOR_USERS or DEVNET_BOR_HOSTS lengths are not equal to the nodes count ' +
+        '(TF_VAR_VALIDATOR_COUNT+TF_VAR_SENTRY_COUNT+TF_VAR_ARCHIVE_COUNT), please check your configs!'
+    )
+    process.exit(1)
   }
-  
+
   borUsers.forEach((user) => {
     if (user !== 'ubuntu') {
       console.log(

--- a/src/setup/bor/index.js
+++ b/src/setup/bor/index.js
@@ -149,16 +149,6 @@ export class Bor {
         await setupTask.run()
         return new Listr(
             [
-                // {
-                //     title: "Clone Bor repository",
-                //     task: () =>
-                //         cloneRepository(
-                //             this.repositoryName,
-                //             this.repositoryBranch,
-                //             this.repositoryUrl,
-                //             this.config.codeDir
-                //         ),
-                // },
                 {
                     title: "Build Bor",
                     task: () =>
@@ -167,19 +157,6 @@ export class Bor {
                             stdio: getRemoteStdio(),
                         }),
                 },
-                // {
-                //     title: "Prepare data directory",
-                //     task: () => {
-                //         return execa(
-                //             "mkdir",
-                //             ["-p", this.config.dataDir, this.borDataDir, this.keystoreDir],
-                //             {
-                //                 cwd: this.config.targetDirectory,
-                //                 stdio: getRemoteStdio(),
-                //             }
-                //         );
-                //     },
-                // },
                 {
                     title: "Prepare keystore and password.txt",
                     task: () => {
@@ -208,26 +185,6 @@ export class Bor {
                         });
                     },
                 },
-                // {
-                //     title: "Process template scripts",
-                //     task: async () => {
-                //         if (this.config.devnetType === "remote") {
-                //             return;
-                //         }
-                //         const templateDir = path.resolve(
-                //             new URL(import.meta.url).pathname,
-                //             "../templates"
-                //         );
-
-                //         // copy all templates to target directory
-                //         await fs.copy(templateDir, this.config.targetDirectory);
-
-                //         // process all njk templates
-                //         await processTemplateFiles(this.config.targetDirectory, {
-                //             obj: this,
-                //         });
-                //     },
-                // },
             ],
             {
                 exitOnError: true,

--- a/src/setup/bor/index.js
+++ b/src/setup/bor/index.js
@@ -24,173 +24,173 @@ export const KEYSTORE_PASSWORD = 'hello'
 //
 
 export class Bor {
-    constructor(config, options = {}) {
-        this.config = config;
+  constructor(config, options = {}) {
+    this.config = config
 
-        this.repositoryName = "bor";
-        this.repositoryBranch = options.repositoryBranch || "develop";
-        this.repositoryUrl =
-            options.repositoryUrl || "https://github.com/maticnetwork/bor";
+    this.repositoryName = 'bor'
+    this.repositoryBranch = options.repositoryBranch || 'develop'
+    this.repositoryUrl =
+      options.repositoryUrl || 'https://github.com/maticnetwork/bor'
 
-        this.genesis = new Genesis(config);
-    }
+    this.genesis = new Genesis(config)
+  }
 
-    get name() {
-        return "bor";
-    }
+  get name() {
+    return 'bor'
+  }
 
-    get taskTitle() {
-        return "Setup Bor";
-    }
+  get taskTitle() {
+    return 'Setup Bor'
+  }
 
-    get repositoryDir() {
-        return path.join(this.config.codeDir, this.repositoryName);
-    }
+  get repositoryDir() {
+    return path.join(this.config.codeDir, this.repositoryName)
+  }
 
-    get buildDir() {
-        return path.join(this.repositoryDir, "build");
-    }
+  get buildDir() {
+    return path.join(this.repositoryDir, 'build')
+  }
 
-    get borDataDir() {
-        return path.join(this.config.dataDir, "bor");
-    }
+  get borDataDir() {
+    return path.join(this.config.dataDir, 'bor')
+  }
 
-    get keystoreDir() {
-        return path.join(this.config.dataDir, "keystore");
-    }
+  get keystoreDir() {
+    return path.join(this.config.dataDir, 'keystore')
+  }
 
-    get passwordFilePath() {
-        return path.join(this.config.dataDir, "password.txt");
-    }
+  get passwordFilePath() {
+    return path.join(this.config.dataDir, 'password.txt')
+  }
 
-    get keystorePassword() {
-        return this.config.keystorePassword || KEYSTORE_PASSWORD;
-    }
+  get keystorePassword() {
+    return this.config.keystorePassword || KEYSTORE_PASSWORD
+  }
 
-    async print() {
-        console.log(
-            chalk.gray("Bor data") + ": " + chalk.bold.green(this.borDataDir)
-        );
-        console.log(
-            chalk.gray("Bor repo") + ": " + chalk.bold.green(this.repositoryDir)
-        );
-        console.log(
-            chalk.gray("Setup bor chain") +
-            ": " +
-            chalk.bold.green("bash bor-setup.sh")
-        );
-        console.log(
-            chalk.gray("Start bor chain") +
-            ": " +
-            chalk.bold.green("bash bor-start.sh")
-        );
-        console.log(
-            chalk.gray("Clean bor chain") +
-            ": " +
-            chalk.bold.green("bash bor-clean.sh")
-        );
-    }
+  async print() {
+    console.log(
+      chalk.gray('Bor data') + ': ' + chalk.bold.green(this.borDataDir)
+    )
+    console.log(
+      chalk.gray('Bor repo') + ': ' + chalk.bold.green(this.repositoryDir)
+    )
+    console.log(
+      chalk.gray('Setup bor chain') +
+        ': ' +
+        chalk.bold.green('bash bor-setup.sh')
+    )
+    console.log(
+      chalk.gray('Start bor chain') +
+        ': ' +
+        chalk.bold.green('bash bor-start.sh')
+    )
+    console.log(
+      chalk.gray('Clean bor chain') +
+        ': ' +
+        chalk.bold.green('bash bor-clean.sh')
+    )
+  }
 
-    async cloneRepositoryAndProcessTemplates() {
-        return new Listr([
-            {
-                title: "Clone Bor repository",
-                task: () =>
-                    cloneRepository(
-                        this.repositoryName,
-                        this.repositoryBranch,
-                        this.repositoryUrl,
-                        this.config.codeDir
-                    ),
-            },
-            {
-                title: "Prepare data directory",
-                task: () => {
-                    return execa(
-                        "mkdir",
-                        ["-p", this.config.dataDir, this.borDataDir, this.keystoreDir],
-                        {
-                            cwd: this.config.targetDirectory,
-                            stdio: getRemoteStdio(),
-                        }
-                    );
-                },
-            },
-            {
-                title: "Process template scripts",
-                task: async () => {
-                    if (this.config.devnetType === "remote") {
-                        return;
-                    }
-                    const templateDir = path.resolve(
-                        new URL(import.meta.url).pathname,
-                        "../templates"
-                    );
-
-                    // copy all templates to target directory
-                    await fs.copy(templateDir, this.config.targetDirectory);
-
-                    // process all njk templates
-                    await processTemplateFiles(this.config.targetDirectory, {
-                        obj: this,
-                    });
-                },
-            },
-            
-
-        ],
+  async cloneRepositoryAndProcessTemplates() {
+    return new Listr(
+      [
         {
-            concurrent: true
-        })
-    }
-
-    async getTasks() {
-        const setupTask = await this.cloneRepositoryAndProcessTemplates()
-        await setupTask.run()
-        return new Listr(
-            [
-                {
-                    title: "Build Bor",
-                    task: () =>
-                        execa("make", ["bor"], {
-                            cwd: this.repositoryDir,
-                            stdio: getRemoteStdio(),
-                        }),
-                },
-                {
-                    title: "Prepare keystore and password.txt",
-                    task: () => {
-                        if (this.config.devnetType === "remote") {
-                            return;
-                        }
-                        // get keystore file and store in keystore file
-                        const keystoreFileObj = getKeystoreFile(
-                            this.config.primaryAccount.privateKey,
-                            this.config.keystorePassword
-                        );
-
-                        // resolve promise
-                        return fs.emptyDir(this.keystoreDir).then(() => {
-                            const p = [
-                                fs.writeFile(
-                                    this.passwordFilePath,
-                                    `${this.config.keystorePassword}\n`
-                                ),
-                                fs.writeFile(
-                                    path.join(this.keystoreDir, keystoreFileObj.keystoreFilename),
-                                    JSON.stringify(keystoreFileObj.keystore, null, 2)
-                                ),
-                            ];
-                            return Promise.all(p);
-                        });
-                    },
-                },
-            ],
-            {
-                exitOnError: true,
+          title: 'Clone Bor repository',
+          task: () =>
+            cloneRepository(
+              this.repositoryName,
+              this.repositoryBranch,
+              this.repositoryUrl,
+              this.config.codeDir
+            )
+        },
+        {
+          title: 'Prepare data directory',
+          task: () => {
+            return execa(
+              'mkdir',
+              ['-p', this.config.dataDir, this.borDataDir, this.keystoreDir],
+              {
+                cwd: this.config.targetDirectory,
+                stdio: getRemoteStdio()
+              }
+            )
+          }
+        },
+        {
+          title: 'Process template scripts',
+          task: async () => {
+            if (this.config.devnetType === 'remote') {
+              return
             }
-        );
-    }
+            const templateDir = path.resolve(
+              new URL(import.meta.url).pathname,
+              '../templates'
+            )
+
+            // copy all templates to target directory
+            await fs.copy(templateDir, this.config.targetDirectory)
+
+            // process all njk templates
+            await processTemplateFiles(this.config.targetDirectory, {
+              obj: this
+            })
+          }
+        }
+      ],
+      {
+        concurrent: true
+      }
+    )
+  }
+
+  async getTasks() {
+    const setupTask = await this.cloneRepositoryAndProcessTemplates()
+    await setupTask.run()
+    return new Listr(
+      [
+        {
+          title: 'Build Bor',
+          task: () =>
+            execa('make', ['bor'], {
+              cwd: this.repositoryDir,
+              stdio: getRemoteStdio()
+            })
+        },
+        {
+          title: 'Prepare keystore and password.txt',
+          task: () => {
+            if (this.config.devnetType === 'remote') {
+              return
+            }
+            // get keystore file and store in keystore file
+            const keystoreFileObj = getKeystoreFile(
+              this.config.primaryAccount.privateKey,
+              this.config.keystorePassword
+            )
+
+            // resolve promise
+            return fs.emptyDir(this.keystoreDir).then(() => {
+              const p = [
+                fs.writeFile(
+                  this.passwordFilePath,
+                  `${this.config.keystorePassword}\n`
+                ),
+                fs.writeFile(
+                  path.join(this.keystoreDir, keystoreFileObj.keystoreFilename),
+                  JSON.stringify(keystoreFileObj.keystore, null, 2)
+                )
+              ]
+              return Promise.all(p)
+            })
+          }
+        }
+      ],
+      {
+        exitOnError: true
+      }
+    )
+  }
 }
 
 async function setupBor(config) {

--- a/src/setup/bor/index.js
+++ b/src/setup/bor/index.js
@@ -24,158 +24,216 @@ export const KEYSTORE_PASSWORD = 'hello'
 //
 
 export class Bor {
-  constructor(config, options = {}) {
-    this.config = config
+    constructor(config, options = {}) {
+        this.config = config;
 
-    this.repositoryName = 'bor'
-    this.repositoryBranch = options.repositoryBranch || 'develop'
-    this.repositoryUrl =
-      options.repositoryUrl || 'https://github.com/maticnetwork/bor'
+        this.repositoryName = "bor";
+        this.repositoryBranch = options.repositoryBranch || "develop";
+        this.repositoryUrl =
+            options.repositoryUrl || "https://github.com/maticnetwork/bor";
 
-    this.genesis = new Genesis(config)
-  }
+        this.genesis = new Genesis(config);
+    }
 
-  get name() {
-    return 'bor'
-  }
+    get name() {
+        return "bor";
+    }
 
-  get taskTitle() {
-    return 'Setup Bor'
-  }
+    get taskTitle() {
+        return "Setup Bor";
+    }
 
-  get repositoryDir() {
-    return path.join(this.config.codeDir, this.repositoryName)
-  }
+    get repositoryDir() {
+        return path.join(this.config.codeDir, this.repositoryName);
+    }
 
-  get borDataDir() {
-    return path.join(this.config.dataDir, 'bor')
-  }
+    get buildDir() {
+        return path.join(this.repositoryDir, "build");
+    }
 
-  get keystoreDir() {
-    return path.join(this.config.dataDir, 'keystore')
-  }
+    get borDataDir() {
+        return path.join(this.config.dataDir, "bor");
+    }
 
-  get passwordFilePath() {
-    return path.join(this.config.dataDir, 'password.txt')
-  }
+    get keystoreDir() {
+        return path.join(this.config.dataDir, "keystore");
+    }
 
-  get keystorePassword() {
-    return this.config.keystorePassword || KEYSTORE_PASSWORD
-  }
+    get passwordFilePath() {
+        return path.join(this.config.dataDir, "password.txt");
+    }
 
-  async print() {
-    console.log(
-      chalk.gray('Bor data') + ': ' + chalk.bold.green(this.borDataDir)
-    )
-    console.log(
-      chalk.gray('Bor repo') + ': ' + chalk.bold.green(this.repositoryDir)
-    )
-    console.log(
-      chalk.gray('Setup bor chain') +
-        ': ' +
-        chalk.bold.green('bash bor-setup.sh')
-    )
-    console.log(
-      chalk.gray('Start bor chain') +
-        ': ' +
-        chalk.bold.green('bash bor-start.sh')
-    )
-    console.log(
-      chalk.gray('Clean bor chain') +
-        ': ' +
-        chalk.bold.green('bash bor-clean.sh')
-    )
-  }
+    get keystorePassword() {
+        return this.config.keystorePassword || KEYSTORE_PASSWORD;
+    }
 
-  async getTasks() {
-    // noinspection JSUnresolvedVariable
-    return new Listr(
-      [
+    async print() {
+        console.log(
+            chalk.gray("Bor data") + ": " + chalk.bold.green(this.borDataDir)
+        );
+        console.log(
+            chalk.gray("Bor repo") + ": " + chalk.bold.green(this.repositoryDir)
+        );
+        console.log(
+            chalk.gray("Setup bor chain") +
+            ": " +
+            chalk.bold.green("bash bor-setup.sh")
+        );
+        console.log(
+            chalk.gray("Start bor chain") +
+            ": " +
+            chalk.bold.green("bash bor-start.sh")
+        );
+        console.log(
+            chalk.gray("Clean bor chain") +
+            ": " +
+            chalk.bold.green("bash bor-clean.sh")
+        );
+    }
+
+    async cloneRepositoryAndProcessTemplates() {
+        return new Listr([
+            {
+                title: "Clone Bor repository",
+                task: () =>
+                    cloneRepository(
+                        this.repositoryName,
+                        this.repositoryBranch,
+                        this.repositoryUrl,
+                        this.config.codeDir
+                    ),
+            },
+            {
+                title: "Prepare data directory",
+                task: () => {
+                    return execa(
+                        "mkdir",
+                        ["-p", this.config.dataDir, this.borDataDir, this.keystoreDir],
+                        {
+                            cwd: this.config.targetDirectory,
+                            stdio: getRemoteStdio(),
+                        }
+                    );
+                },
+            },
+            {
+                title: "Process template scripts",
+                task: async () => {
+                    if (this.config.devnetType === "remote") {
+                        return;
+                    }
+                    const templateDir = path.resolve(
+                        new URL(import.meta.url).pathname,
+                        "../templates"
+                    );
+
+                    // copy all templates to target directory
+                    await fs.copy(templateDir, this.config.targetDirectory);
+
+                    // process all njk templates
+                    await processTemplateFiles(this.config.targetDirectory, {
+                        obj: this,
+                    });
+                },
+            },
+            
+
+        ],
         {
-          title: 'Clone Bor repository',
-          task: () =>
-            cloneRepository(
-              this.repositoryName,
-              this.repositoryBranch,
-              this.repositoryUrl,
-              this.config.codeDir
-            )
-        },
-        {
-          title: 'Build Bor',
-          task: () =>
-            execa('make', ['bor'], {
-              cwd: this.repositoryDir,
-              stdio: getRemoteStdio()
-            })
-        },
-        {
-          title: 'Prepare data directory',
-          task: () => {
-            return execa(
-              'mkdir',
-              ['-p', this.config.dataDir, this.borDataDir, this.keystoreDir],
-              {
-                cwd: this.config.targetDirectory,
-                stdio: getRemoteStdio()
-              }
-            )
-          }
-        },
-        {
-          title: 'Prepare keystore and password.txt',
-          task: () => {
-            if (this.config.devnetType === 'remote') {
-              return
+            concurrent: true
+        })
+    }
+
+    async getTasks() {
+        const setupTask = await this.cloneRepositoryAndProcessTemplates()
+        await setupTask.run()
+        return new Listr(
+            [
+                // {
+                //     title: "Clone Bor repository",
+                //     task: () =>
+                //         cloneRepository(
+                //             this.repositoryName,
+                //             this.repositoryBranch,
+                //             this.repositoryUrl,
+                //             this.config.codeDir
+                //         ),
+                // },
+                {
+                    title: "Build Bor",
+                    task: () =>
+                        execa("make", ["bor"], {
+                            cwd: this.repositoryDir,
+                            stdio: getRemoteStdio(),
+                        }),
+                },
+                // {
+                //     title: "Prepare data directory",
+                //     task: () => {
+                //         return execa(
+                //             "mkdir",
+                //             ["-p", this.config.dataDir, this.borDataDir, this.keystoreDir],
+                //             {
+                //                 cwd: this.config.targetDirectory,
+                //                 stdio: getRemoteStdio(),
+                //             }
+                //         );
+                //     },
+                // },
+                {
+                    title: "Prepare keystore and password.txt",
+                    task: () => {
+                        if (this.config.devnetType === "remote") {
+                            return;
+                        }
+                        // get keystore file and store in keystore file
+                        const keystoreFileObj = getKeystoreFile(
+                            this.config.primaryAccount.privateKey,
+                            this.config.keystorePassword
+                        );
+
+                        // resolve promise
+                        return fs.emptyDir(this.keystoreDir).then(() => {
+                            const p = [
+                                fs.writeFile(
+                                    this.passwordFilePath,
+                                    `${this.config.keystorePassword}\n`
+                                ),
+                                fs.writeFile(
+                                    path.join(this.keystoreDir, keystoreFileObj.keystoreFilename),
+                                    JSON.stringify(keystoreFileObj.keystore, null, 2)
+                                ),
+                            ];
+                            return Promise.all(p);
+                        });
+                    },
+                },
+                // {
+                //     title: "Process template scripts",
+                //     task: async () => {
+                //         if (this.config.devnetType === "remote") {
+                //             return;
+                //         }
+                //         const templateDir = path.resolve(
+                //             new URL(import.meta.url).pathname,
+                //             "../templates"
+                //         );
+
+                //         // copy all templates to target directory
+                //         await fs.copy(templateDir, this.config.targetDirectory);
+
+                //         // process all njk templates
+                //         await processTemplateFiles(this.config.targetDirectory, {
+                //             obj: this,
+                //         });
+                //     },
+                // },
+            ],
+            {
+                exitOnError: true,
             }
-            // get keystore file and store in keystore file
-            const keystoreFileObj = getKeystoreFile(
-              this.config.primaryAccount.privateKey,
-              this.config.keystorePassword
-            )
-
-            // resolve promise
-            return fs.emptyDir(this.keystoreDir).then(() => {
-              const p = [
-                fs.writeFile(
-                  this.passwordFilePath,
-                  `${this.config.keystorePassword}\n`
-                ),
-                fs.writeFile(
-                  path.join(this.keystoreDir, keystoreFileObj.keystoreFilename),
-                  JSON.stringify(keystoreFileObj.keystore, null, 2)
-                )
-              ]
-              return Promise.all(p)
-            })
-          }
-        },
-        {
-          title: 'Process template scripts',
-          task: async () => {
-            if (this.config.devnetType === 'remote') {
-              return
-            }
-            const templateDir = path.resolve(
-              new URL(import.meta.url).pathname,
-              '../templates'
-            )
-
-            // copy all templates to target directory
-            await fs.copy(templateDir, this.config.targetDirectory)
-
-            // process all njk templates
-            await processTemplateFiles(this.config.targetDirectory, {
-              obj: this
-            })
-          }
-        }
-      ],
-      {
-        exitOnError: true
-      }
-    )
-  }
+        );
+    }
 }
 
 async function setupBor(config) {

--- a/src/setup/bor/index.js
+++ b/src/setup/bor/index.js
@@ -1,6 +1,6 @@
 // noinspection JSUnresolvedFunction,JSUnresolvedVariable
 
-import Listr from 'listr'
+import { Listr } from 'listr2'
 import execa from 'execa'
 import chalk from 'chalk'
 import path from 'path'

--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -784,7 +784,7 @@ export class Devnet {
                           "--v",
                             this.config.numOfValidators,
                             "--n",
-                            this.config.numOfNonValidators,
+                            this.config.numOfNonValidators + this.config.numOfArchiveNodes,
                             "--chain-id",
                             this.config.heimdallChainId,
                             "--node-host-prefix",

--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -384,117 +384,7 @@ export class Devnet {
     const initRemoteTasks = await this.initRemoteTasks()
     await initRemoteTasks.run()
 
-    //const enodeTask = await this.getEnodeTask()
     return [
-      // enodeTask,
-      // {
-      //   title: 'Process Heimdall configs',
-      //   task: async () => {
-      //     // set heimdall
-      //     for (let i = 0; i < this.totalNodes; i++) {
-      //       fileReplacer(this.heimdallHeimdallConfigFilePath(i))
-      //         .replace(
-      //           /eth_rpc_url[ ]*=[ ]*".*"/gi,
-      //           `eth_rpc_url = "${this.config.ethURL}"`
-      //         )
-      //         .replace(
-      //           /bor_rpc_url[ ]*=[ ]*".*"/gi,
-      //           'bor_rpc_url = "http://localhost:8545"'
-      //         )
-      //         .replace(
-      //           /amqp_url[ ]*=[ ]*".*"/gi,
-      //           'amqp_url = "amqp://guest:guest@localhost:5672/"'
-      //         )
-      //         .save()
-      //     }
-      //   }
-      // },
-      // {
-      //   title: 'Process contract addresses',
-      //   task: () => {
-      //     // get root contracts
-      //     const rootContracts = this.config.contractAddresses.root
-
-      //     // set heimdall peers with devnet heimdall hosts
-      //     for (let i = 0; i < this.totalNodes; i++) {
-      //       fileReplacer(this.heimdallGenesisFilePath(i))
-      //         .replace(
-      //           /"matic_token_address":[ ]*".*"/gi,
-      //           `"matic_token_address": "${rootContracts.tokens.TestToken}"`
-      //         )
-      //         .replace(
-      //           /"staking_manager_address":[ ]*".*"/gi,
-      //           `"staking_manager_address": "${rootContracts.StakeManagerProxy}"`
-      //         )
-      //         .replace(
-      //           /"root_chain_address":[ ]*".*"/gi,
-      //           `"root_chain_address": "${rootContracts.RootChainProxy}"`
-      //         )
-      //         .replace(
-      //           /"staking_info_address":[ ]*".*"/gi,
-      //           `"staking_info_address": "${rootContracts.StakingInfo}"`
-      //         )
-      //         .replace(
-      //           /"state_sender_address":[ ]*".*"/gi,
-      //           `"state_sender_address": "${rootContracts.StateSender}"`
-      //         )
-      //         .save()
-      //     }
-      //   },
-      //   enabled: () => {
-      //     return this.config.contractAddresses
-      //   }
-      // },
-      // {
-      //   title: 'Process templates',
-      //   task: async () => {
-      //     const templateDir = path.resolve(
-      //       new URL(import.meta.url).pathname,
-      //       '../templates'
-      //     )
-
-      //     // copy remote related templates
-      //     await fs.copy(
-      //       path.join(templateDir, 'remote'),
-      //       this.config.targetDirectory
-      //     )
-
-      //     // promises
-      //     const p = []
-      //     const signerDumpData = this.signerDumpData
-      //     // process njk files
-      //     for (const file of getAllFiles(this.config.targetDirectory, [])) {
-      //       if (file.indexOf('.njk') !== -1) {
-      //         const fp = path.join(this.config.targetDirectory, file)
-
-      //         // process all njk files and copy to each node directory
-      //         for (let i = 0; i < this.totalNodes; i++) {
-      //           const file2array = file.split('/')
-      //           const file2 = file2array[file2array.length - 1]
-      //           fs.writeFileSync(
-      //             path.join(this.nodeDir(i), file2.replace('.njk', '')),
-      //             nunjucks.render(file, {
-      //               obj: this,
-      //               node: i,
-      //               signerData: signerDumpData[i]
-      //             })
-      //           )
-      //         }
-
-      //         // remove njk file
-      //         p.push(
-      //           execa('rm', ['-rf', fp], {
-      //             cwd: this.config.targetDirectory,
-      //             stdio: getRemoteStdio()
-      //           })
-      //         )
-      //       }
-      //     }
-
-      //     // fulfill all promises
-      //     await Promise.all(p)
-      //   }
-      // },
       {
         title: 'Copy files to remote servers',
         task: async () => {
@@ -832,66 +722,6 @@ export class Devnet {
                     },
                 },
             ])
-        // return [
-        //     heimdall.cloneRepositoryTask(),
-        //     heimdall.buildTask(),
-        //     {
-        //         title: "Create testnet files for Heimdall",
-        //         task: async () => {
-        //             const args = [
-        //               "create-testnet",
-        //               "--home", "devnet",
-        //               "--v",
-        //                 this.config.numOfValidators,
-        //                 "--n",
-        //                 this.config.numOfNonValidators,
-        //                 "--chain-id",
-        //                 this.config.heimdallChainId,
-        //                 "--node-host-prefix",
-        //                 "heimdall",
-        //                 "--output-dir",
-        //                 "devnet",
-        //             ];
-
-        //             // Create heimdall folders
-        //             if (this.config.devnetType === "remote") {
-        //                 // create heimdall folder for all the nodes in remote setup
-        //                 for (let i = 0; i < this.totalNodes; i++) {
-        //                         await execa('ssh', [
-        //                             `-o`, `StrictHostKeyChecking=no`, `-o`, `UserKnownHostsFile=/dev/null`,
-        //                             `-i`, `~/cert.pem`,
-        //                             `${this.config.devnetBorUsers[i]}@${this.config.devnetBorHosts[i]}`,
-        //                             `sudo mkdir -p /var/lib/heimdall && sudo chmod 777 -R /var/lib/heimdall/`
-        //                         ], {stdio: getRemoteStdio()})
-
-        //                 }
-        //             }
-
-        //             // create testnet
-        //             await execa(heimdall.heimdalldCmd, args, {
-        //                 cwd: this.config.targetDirectory,
-        //                 stdio: getRemoteStdio(),
-        //             });
-
-        //             // set heimdall peers with devnet heimdall hosts
-        //             for (let i = 0; i < this.totalNodes; i++) {
-        //                 fileReplacer(this.heimdallConfigFilePath(i))
-        //                     .replace(/heimdall([^:]+):/gi, (d, index) => {
-        //                         return `${this.config.devnetHeimdallHosts[index]}:`;
-        //                     })
-        //                     .replace(/moniker.+=.+/gi, `moniker = "heimdall${i}"`)
-        //                     .save();
-
-        //                 fileReplacer(this.heimdallGenesisFilePath(i))
-        //                     .replace(
-        //                         /"bor_chain_id"[ ]*:[ ]*".*"/gi,
-        //                         `"bor_chain_id": "${this.config.borChainId}"`
-        //                     )
-        //                     .save();
-        //             }
-        //         },
-        //     },
-        // ];
     }
 
     async borTask(bor) {
@@ -974,9 +804,6 @@ export class Devnet {
         const createTestnetTasks = await this.getCreateTestnetTask(heimdall);
         await createTestnetTasks.run()
 
-        //const borTasks = await this.borTask(bor)
-        //await borTasks.run()
-
         const accountTasks = await this.accountTask()
         await accountTasks.run()
 
@@ -984,29 +811,6 @@ export class Devnet {
         await genesisTasks.run()
 
         return new Listr([
-            //...createTestnetTasks,
-            // {
-            //     title: "Setup accounts",
-            //     task: () => {
-            //         // set validator addresses
-            //         const genesisAddresses = [];
-            //         const signerDumpData = this.signerDumpData;
-            //         for (let i = 0; i < this.config.numOfValidators; i++) {
-            //             const d = signerDumpData[i];
-            //             genesisAddresses.push(d.address);
-            //         }
-
-            //         // set genesis addresses
-            //         this.config.genesisAddresses = genesisAddresses;
-
-            //         // setup accounts from signer dump data (based on number of validators)
-            //         this.config.accounts = this.signerDumpData
-            //             .slice(0, this.config.numOfValidators)
-            //             .map((s) => {
-            //                 return getAccountFromPrivateKey(s.priv_key);
-            //             });
-            //     },
-            // },
             {
                 title: bor.taskTitle,
                 task: () => {
@@ -1016,13 +820,6 @@ export class Devnet {
                     return this.config.devnetType === "remote";
                 },
             },
-            // {
-            //     title: genesis.taskTitle,
-            //     task: () => {
-            //         // get genesis tasks
-            //         return genesis.getTasks();
-            //     },
-            // },
             {
                 title: "Setup Bor keystore and genesis files",
                 task: async () => {
@@ -1110,26 +907,6 @@ export class Devnet {
                     return this.config.devnetType === "docker" || "remote";
                 },
             },
-            // {
-            //     title: "Docker",
-            //     task: async () => {
-            //         const tasks = await this.getDockerTasks();
-            //         return new Listr(tasks);
-            //     },
-            //     enabled: () => {
-            //         return this.config.devnetType === "docker";
-            //     },
-            // },
-            // {
-            //     title: "Remote",
-            //     task: async () => {
-            //         const tasks = await this.getRemoteTasks();
-            //         return new Listr(tasks);
-            //     },
-            //     enabled: () => {
-            //         return this.config.devnetType === "remote";
-            //     },
-            // },
         ],
         {
             concurrent: true

--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -1,7 +1,7 @@
 // noinspection JSUnresolvedFunction,JSUnresolvedVariable
 
 import inquirer from 'inquirer'
-import Listr from 'listr'
+import { Listr } from 'listr2'
 import path from 'path'
 import chalk from 'chalk'
 import execa from 'execa'

--- a/src/setup/ganache/index.js
+++ b/src/setup/ganache/index.js
@@ -1,6 +1,6 @@
 // noinspection JSCheckFunctionSignatures
 
-import Listr from 'listr'
+import { Listr } from 'listr2'
 import chalk from 'chalk'
 import path from 'path'
 import execa from 'execa'

--- a/src/setup/genesis/index.js
+++ b/src/setup/genesis/index.js
@@ -1,6 +1,6 @@
 // noinspection JSUnresolvedVariable
 
-import Listr from 'listr'
+import { Listr } from 'listr2'
 import execa from 'execa'
 import chalk from 'chalk'
 import inquirer from 'inquirer'

--- a/src/setup/heimdall/index.js
+++ b/src/setup/heimdall/index.js
@@ -4,7 +4,7 @@ import Listr from 'listr'
 import execa from 'execa'
 import chalk from 'chalk'
 import path from 'path'
-import fs from 'fs-extra'
+import fs, { truncate } from 'fs-extra'
 
 import fileReplacer from '../../lib/file-replacer'
 import { loadConfig } from '../config'
@@ -221,7 +221,8 @@ export class Heimdall {
         }
       ],
       {
-        exitOnError: true
+        exitOnError: true,
+        concurrent: true
       }
     )
   }

--- a/src/setup/heimdall/index.js
+++ b/src/setup/heimdall/index.js
@@ -4,7 +4,7 @@ import { Listr } from 'listr2'
 import execa from 'execa'
 import chalk from 'chalk'
 import path from 'path'
-import fs, { truncate } from 'fs-extra'
+import fs from 'fs-extra'
 
 import fileReplacer from '../../lib/file-replacer'
 import { loadConfig } from '../config'

--- a/src/setup/heimdall/index.js
+++ b/src/setup/heimdall/index.js
@@ -1,6 +1,6 @@
 // noinspection JSUnresolvedFunction,JSUnresolvedVariable
 
-import Listr from 'listr'
+import { Listr } from 'listr2'
 import execa from 'execa'
 import chalk from 'chalk'
 import path from 'path'

--- a/src/setup/localnet/index.js
+++ b/src/setup/localnet/index.js
@@ -1,6 +1,6 @@
 // noinspection JSUnresolvedVariable
 
-import Listr from 'listr'
+import { Listr } from 'listr2'
 import chalk from 'chalk'
 import path from 'path'
 import fs from 'fs-extra'


### PR DESCRIPTION
# Description

This PR introduces some concurrency while executing the setup tasks in matic-cli wherever applicable. It also updates Listr (which is the dependency used in matic-cli for organizing and executing the network setup jobs) to Listr2 in favour of a well maintained but also a like-for-like replacement.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
