### PR TITLE
Rewind feature for express-cli devnet, POS-1080

### DIFF
--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -319,6 +319,6 @@ export async function cli() {
     }
 
     await timer(3000)
-    await rewind(options.rewind) 
+    await rewind(options.rewind)
   }
 }

--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -314,9 +314,6 @@ export async function cli() {
       )
       process.exit(1)
     }
-
-    console.log(options.rewind)
-
     if (options.rewind === true) {
       options.rewind = 100
     }

--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -19,6 +19,7 @@ import pkg from '../package.json'
 import { testEip1559 } from '../tests/test-eip-1559'
 import { stopInstances } from './express/commands/instances-stop'
 import { startInstances } from './express/commands/instances-start'
+import { rewind } from './express/commands/rewind'
 
 const timer = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -65,6 +66,7 @@ program
   .option('-xxx, --chaos [intensity]', 'Start Chaos')
   .option('-istop, --instances-stop', 'Stop aws ec2 instances')
   .option('-istart, --instances-start', 'Start aws ec2 instances')
+  .option('-rewind, --rewind [numberOfBlocks]', 'Rewind the chain')
   .version(pkg.version)
 
 export async function cli() {
@@ -304,5 +306,22 @@ export async function cli() {
     }
     await timer(3000)
     await startInstances()
+  } else if (options.rewind) {
+    console.log('📍Command --rewind')
+    if (!checkDir(false)) {
+      console.log(
+        '❌ The command is not called from the appropriate devnet directory!'
+      )
+      process.exit(1)
+    }
+
+    console.log(options.rewind)
+
+    if (options.rewind === true) {
+      options.rewind = 100
+    }
+
+    await timer(3000)
+    await rewind(options.rewind) 
   }
 }

--- a/src/express/commands/rewind.js
+++ b/src/express/commands/rewind.js
@@ -6,10 +6,10 @@ const {
 } = require('../common/remote-worker')
 
 export async function rewind(num) {
-  //   num = number of blocks to rewind
+  // num = number of blocks to rewind
   if (num > 128) {
     console.log(
-      '📍number of blocks to rewind should should be less than equal to 128, setting to 128'
+      '📍 Number of blocks to rewind should be less than or equal to 128, setting to 128'
     )
     num = 128
   }
@@ -24,16 +24,16 @@ export async function rewind(num) {
   const borHosts = splitToArray(doc.devnetBorHosts.toString())
 
   if (doc.devnetBorHosts.length > 0) {
-    console.log('📍Monitoring the first node', doc.devnetBorHosts[0])
+    console.log('📍 Monitoring the first node', doc.devnetBorHosts[0])
   } else {
-    console.log('📍No nodes to monitor, please check your configs! Exiting...')
+    console.log('📍 No nodes to monitor, please check your configs! Exiting...')
     process.exit(1)
   }
 
   const ip = `${borUsers[0]}@${borHosts[0]}`
 
   const getBlockNumberCommand =
-    '/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "eth.blockNumber"'
+    '~/go/bin/bor attach ~/.bor/data/bor.ipc --exec "eth.blockNumber"'
 
   const intitalBlockNumber = await runSshCommandWithReturn(
     ip,
@@ -41,10 +41,10 @@ export async function rewind(num) {
     maxRetries
   )
   console.log(
-    `⏪ rewinding chain by ${num} blocks, \n⛓ current block number: ${intitalBlockNumber}`
+    `📍 rewinding chain by ${num} blocks, \n📍 current block number: ${intitalBlockNumber}`
   )
 
-  const rewindCommand = `/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "debug.setHead(web3.toHex(${intitalBlockNumber} - ${num}))"`
+  const rewindCommand = `~/go/bin/bor attach ~/.bor/data/bor.ipc --exec "debug.setHead(web3.toHex(${intitalBlockNumber} - ${num}))"`
   await runSshCommand(ip, rewindCommand, maxRetries)
 
   const restartCommand = 'sudo service bor restart'
@@ -56,14 +56,14 @@ export async function rewind(num) {
     maxRetries
   )
   console.log(
-    `⏪ rewinded chain by ${
+    `📍 rewinded chain by ${
       intitalBlockNumber - rewindedBlockNumber
-    } blocks, \n⛓ current block number ${rewindedBlockNumber}`
+    } blocks, \n📍 current block number ${rewindedBlockNumber}`
   )
 
   console.log(
     'NOTE: minor difference in block number is expected due to small block time'
   )
 
-  console.log('📍Done! Exiting...')
+  console.log('📍 Done! Exiting...')
 }

--- a/src/express/commands/rewind.js
+++ b/src/express/commands/rewind.js
@@ -1,0 +1,54 @@
+import { loadDevnetConfig, splitToArray } from '../common/config-utils'
+import Web3 from 'web3'
+const {
+  runSshCommand,
+  maxRetries
+} = require('../common/remote-worker')
+const web3 = new Web3()
+
+// return hex from decimal
+export function decToHex(dec) {
+  return web3.utils.toHex(dec)
+}
+
+export async function rewind(num) {
+  //   num = number of blocks to rewind
+  if (num > 128) {
+    console.log(
+      '📍number of blocks to rewind should should be less than 128, set to 127'
+    )
+    num = 128
+  }
+  console.log('📍Command --chaos [numberOfBlocks]', num)
+
+  require('dotenv').config({ path: `${process.cwd()}/.env` })
+  const devnetType =
+    process.env.TF_VAR_DOCKERIZED === 'yes' ? 'docker' : 'remote'
+
+  const doc = await loadDevnetConfig(devnetType)
+
+  const borUsers = splitToArray(doc['devnetBorUsers'].toString())
+  const borHosts = splitToArray(doc['devnetBorHosts'].toString())
+
+  if (doc['devnetBorHosts'].length > 0) {
+    console.log('📍Monitoring the first node', doc['devnetBorHosts'][0])
+  } else {
+    console.log('📍No nodes to monitor, please check your configs! Exiting...')
+    process.exit(1)
+  }
+
+  const ip = `${borUsers[0]}@${borHosts[0]}`
+
+  const getBlockNumberCommand = `/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "eth.blockNumber"`
+  console.log(`📍rewinding chain by ${num} blocks, \ncurrent block number:`)
+  await runSshCommand(ip, getBlockNumberCommand, maxRetries)
+
+  const rewindCommand = `/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "debug.setHead(web3.toHex(eth.blockNumber - ${num}))"`
+  await runSshCommand(ip, rewindCommand, maxRetries)
+
+  const restartCommand = `sudo service bor restart`  
+  await runSshCommand(ip, restartCommand, maxRetries)
+
+  console.log(`📍rewinded chain by ${num} blocks, \ncurrent block number`)
+  await runSshCommand(ip, getBlockNumberCommand, maxRetries)
+}

--- a/src/express/commands/rewind.js
+++ b/src/express/commands/rewind.js
@@ -20,11 +20,11 @@ export async function rewind(num) {
 
   const doc = await loadDevnetConfig(devnetType)
 
-  const borUsers = splitToArray(doc['devnetBorUsers'].toString())
-  const borHosts = splitToArray(doc['devnetBorHosts'].toString())
+  const borUsers = splitToArray(doc.devnetBorUsers.toString())
+  const borHosts = splitToArray(doc.devnetBorHosts.toString())
 
-  if (doc['devnetBorHosts'].length > 0) {
-    console.log('📍Monitoring the first node', doc['devnetBorHosts'][0])
+  if (doc.devnetBorHosts.length > 0) {
+    console.log('📍Monitoring the first node', doc.devnetBorHosts[0])
   } else {
     console.log('📍No nodes to monitor, please check your configs! Exiting...')
     process.exit(1)
@@ -32,21 +32,38 @@ export async function rewind(num) {
 
   const ip = `${borUsers[0]}@${borHosts[0]}`
 
-  const getBlockNumberCommand = `/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "eth.blockNumber"`
-  
-  const intitalBlockNumber = await runSshCommandWithReturn(ip, getBlockNumberCommand, maxRetries)
-  console.log(`⏪ rewinding chain by ${num} blocks, \n⛓ current block number: ${intitalBlockNumber}`)
+  const getBlockNumberCommand =
+    '/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "eth.blockNumber"'
+
+  const intitalBlockNumber = await runSshCommandWithReturn(
+    ip,
+    getBlockNumberCommand,
+    maxRetries
+  )
+  console.log(
+    `⏪ rewinding chain by ${num} blocks, \n⛓ current block number: ${intitalBlockNumber}`
+  )
 
   const rewindCommand = `/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "debug.setHead(web3.toHex(${intitalBlockNumber} - ${num}))"`
   await runSshCommand(ip, rewindCommand, maxRetries)
 
-  const restartCommand = `sudo service bor restart`  
+  const restartCommand = 'sudo service bor restart'
   await runSshCommand(ip, restartCommand, maxRetries)
 
-  const rewindedBlockNumber = await runSshCommandWithReturn(ip, getBlockNumberCommand, maxRetries)
-  console.log(`⏪ rewinded chain by ${intitalBlockNumber - rewindedBlockNumber} blocks, \n⛓ current block number ${rewindedBlockNumber}`)
+  const rewindedBlockNumber = await runSshCommandWithReturn(
+    ip,
+    getBlockNumberCommand,
+    maxRetries
+  )
+  console.log(
+    `⏪ rewinded chain by ${
+      intitalBlockNumber - rewindedBlockNumber
+    } blocks, \n⛓ current block number ${rewindedBlockNumber}`
+  )
 
-  console.log('NOTE: minor difference in block number is expected due to small block time')
+  console.log(
+    'NOTE: minor difference in block number is expected due to small block time'
+  )
 
   console.log('📍Done! Exiting...')
 }

--- a/src/express/common/remote-worker.js
+++ b/src/express/common/remote-worker.js
@@ -56,19 +56,16 @@ export async function runSshCommandWithReturn(ip, command, retries) {
     process.exit(1)
   }
   try {
-    const { stdout } = await execa(
-      'ssh',
-      [
-        '-o',
-        'StrictHostKeyChecking=no',
-        '-o',
-        'UserKnownHostsFile=/dev/null',
-        '-i',
-        `${process.env.PEM_FILE_PATH}`,
-        ip,
-        command + ' && exit'
-      ]
-    )
+    const { stdout } = await execa('ssh', [
+      '-o',
+      'StrictHostKeyChecking=no',
+      '-o',
+      'UserKnownHostsFile=/dev/null',
+      '-i',
+      `${process.env.PEM_FILE_PATH}`,
+      ip,
+      command + ' && exit'
+    ])
 
     return stdout
   } catch (error) {

--- a/src/express/common/remote-worker.js
+++ b/src/express/common/remote-worker.js
@@ -47,6 +47,45 @@ export async function runSshCommand(ip, command, retries) {
   }
 }
 
+export async function runSshCommandWithReturn(ip, command, retries) {
+  if (retries < 0) {
+    console.log(
+      '❌ runSshCommand called with negative retries number: ',
+      retries
+    )
+    process.exit(1)
+  }
+  try {
+    const { stdout } = await execa(
+      'ssh',
+      [
+        '-o',
+        'StrictHostKeyChecking=no',
+        '-o',
+        'UserKnownHostsFile=/dev/null',
+        '-i',
+        `${process.env.PEM_FILE_PATH}`,
+        ip,
+        command + ' && exit'
+      ]
+    )
+
+    return stdout
+  } catch (error) {
+    if (retries - 1 > 0) {
+      await runSshCommandWithReturn(ip, command, retries - 1)
+    } else {
+      console.log(
+        '❌ Command \n `' +
+          command +
+          '`\n failed too many times with error : \n',
+        error
+      )
+      process.exit(1)
+    }
+  }
+}
+
 export async function runSshCommandWithoutExit(ip, command, retries) {
   if (retries < 0) {
     console.log(


### PR DESCRIPTION
# Description

added a function for testing rewind in devnet blockchain. 

`../../bin/express-cli --rewind [numberOfBlocks]`, by default numberOfBlocks is 100. This will rewind the chain by the specified number of blocks. If numberOfBlocks > 128, it will rewind the chain by 128 blocks.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] New test case for remote devnet

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

#### It should never be the case...

- [ ] This PR requires changes to bor
  - In case link the PR here:
- [ ] This PR requires changes to heimdall
  - In case link the PR here:

## Testing

- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
