### PR TITLE
Change default EBS volume to 100GB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@
 TF_VAR_AWS_PROFILE=default# do not change this
 TF_VAR_VM_NAME=YOUR_IDENTIFIER# default "polygon-user". It can be any string, used to discriminate between instances
 TF_VAR_DOCKERIZED=no# default "no", otherwise only one VM is created and the Polygon devnet will run in docker containers
-TF_VAR_DISK_SIZE_GB=500# size of the disk in GB (default is 500GB)
-TF_VAR_ARCHIVE_DISK_SIZE_GB=500 # size of the disk in GB in archive node (default is 500GB)
+TF_VAR_DISK_SIZE_GB=100# size of the disk in GB (default is 100GB)
+TF_VAR_ARCHIVE_DISK_SIZE_GB=100 # size of the disk in GB in archive node (default is 100GB)
 TF_VAR_IOPS=3000# Amount of provisioned IOPS
 TF_VAR_ARCHIVE_IOPS=15000 # Amount of provisioned IOPS in archive node
 TF_VAR_VALIDATOR_COUNT=2# number of validator nodes (default is 2)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use the `express-cli` you have to execute the following steps.
   accordingly
 - use `TF_VAR_DOCKERZIED=no` to have one VM per node, otherwise the stack will run on one VM only in a dockerized environment
 - (optional) replace `TF_VAR_VM_NAME` with your own identifier (it can be any string, default is "polygon-user")
-- (optional) replace `TF_VAR_DISK_SIZE_GB` with your preferred disk size in GB (default is 500 GB)
+- (optional) replace `TF_VAR_DISK_SIZE_GB` with your preferred disk size in GB (default is 100 GB)
 - `VERBOSE=true` prints logs from the remote machines. If set to `false`, only `express-cli` and `matic-cli` logs will
   be shown
 - **If you are a Polygon employee**, please refer to [this page](https://www.notion.so/polygontechnology/Testing-Toolkit-d47e098641d14c80b2e9a90b3b1b88d9) for more info

--- a/variables.tf
+++ b/variables.tf
@@ -9,11 +9,11 @@ variable "VM_NAME" {
 }
 
 variable "DISK_SIZE_GB" {
-  default = "500"
+  default = "100"
 }
 
 variable "ARCHIVE_DISK_SIZE_GB" {
-  default = "500"
+  default = "100"
 }
 
 variable "IOPS" {


### PR DESCRIPTION
# Description

Most use cases won't need 500GB of disk storage. Changing the default value will reduce cost significantly.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

#### It should never be the case...

- [ ] This PR requires changes to bor
  - In case link the PR here:
- [ ] This PR requires changes to heimdall
  - In case link the PR here:

## Testing

- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
