### PR TITLE
fix: use bor_getAuthor instead of block.miner to fetch block miner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,4 +54,4 @@ STRESS_DEBUG_LOGS=false# boolean flag to enable debug logs for the stress tests
 BURN_CONTRACT_ADDRESS=0x000000000000000000000000000000000000dead# Burn contract address
 MAX_FEE=30000000009# Max fee per gas
 MAX_PRIORITY_FEE=30000000000# Max priority fee per gas
-COUNT=100# Number of times to execute the test
+COUNT=10# Number of times to execute the test


### PR DESCRIPTION
# Description

Earlier when fetching a block via `getBlock` returned the block producer address instead of `0x00...` in the `block.miner` field. This change was reverted in maticnetwork/bor#631 . This led to breaking some assertions in EIP-1559 test script. This PR fixes that.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply


## Testing

- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai

