### PR TITLE
dev: add: stop services before stopping ec2 instances

### DIFF
--- a/src/express/commands/cleanup.js
+++ b/src/express/commands/cleanup.js
@@ -11,7 +11,7 @@ export async function cleanup() {
   await deployBorContractsAndStateSync(doc)
 }
 
-async function stopServices(doc) {
+export async function stopServices(doc) {
   const borUsers = splitToArray(doc.devnetBorUsers.toString())
   const nodeIps = []
   const isHostMap = new Map()

--- a/src/express/commands/instances-stop.js
+++ b/src/express/commands/instances-stop.js
@@ -2,6 +2,7 @@
 
 import { loadDevnetConfig } from '../common/config-utils'
 import { timer } from '../common/time-utils'
+import { stopServices } from './cleanup'
 
 const shell = require('shelljs')
 
@@ -10,7 +11,10 @@ export async function stopInstances() {
   require('dotenv').config({ path: `${process.cwd()}/.env` })
   const devnetType =
     process.env.TF_VAR_DOCKERIZED === 'yes' ? 'docker' : 'remote'
+
   const doc = await loadDevnetConfig(devnetType)
+  await stopServices(doc)
+
   const instances = doc.instancesIds.toString().replace(/,/g, ' ')
 
   shell.exec(`aws ec2 stop-instances --instance-ids ${instances}`)


### PR DESCRIPTION
# Description

With this PR, we gracefully stop all services running on the remote machines of a devnet before stopping the ec2 instances.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
