### PR TITLE
mardizzone/POS-1058: run devnets behind VPN and Bastillion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ test
 .DS_Store
 devnet
 .env
+*.tfvars
 .terraform*
 terraform.tfstate
 terraform.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ To use the `express-cli` you have to execute the following steps.
   by running `nvm use` from the root folder
 - install `express-cli` and `matic-cli` locally with command `npm i`
 - generate a keypair on AWS EC2 and download its certificate locally (`.pem` file)
+- copy `secret.tfvars.example` to `secret.tfvar` with command `cp secret.tfvars.example secret.tfvars` and check the commented file for details
+- **If you are a Polygon employee**, connect to the company VPN
+- modify `secret.tfvar` with addresses of the allowed IPs (as specified in `secret.tfvars.example` file)
 - copy `.env.example` to `.env` with command `cp .env.example .env` and check the heavily commented file for details
 - make sure `PEM_FILE_PATH` points to a correct AWS key certificate, the one you downloaded in the previous steps
 - define the number of nodes (`TF_VAR_VALIDATOR_COUNT` and `TF_VAR_SENTRY_COUNT`) and adjust the `DEVNET_BOR_USERS`

--- a/configs/devnet/docker-setup-config.yaml
+++ b/configs/devnet/docker-setup-config.yaml
@@ -16,6 +16,7 @@ blockNumber: '0'
 blockTime: '2'
 numOfValidators: 1
 numOfNonValidators: 1
+numOfArchiveNodes: 0
 ethURL: http://ganache:9545
 ethHostUser: ubuntu
 devnetType: docker
@@ -23,4 +24,4 @@ borDockerBuildContext: https://github.com/maticnetwork/bor.git#develop
 heimdallDockerBuildContext: https://github.com/maticnetwork/heimdall.git#develop
 devnetBorUsers: ubuntu,ubuntu
 devnetBorHosts:
-  - ec2-xx-xxx-xx-xxx.us-west-2.compute.amazonaws.com
+  - ec2-xx-xxx-xx-xxx.us-west-2.compute.amazonaws.com # use localhost for local deployments

--- a/configs/devnet/docker-setup-config.yaml
+++ b/configs/devnet/docker-setup-config.yaml
@@ -23,4 +23,4 @@ borDockerBuildContext: https://github.com/maticnetwork/bor.git#develop
 heimdallDockerBuildContext: https://github.com/maticnetwork/heimdall.git#develop
 devnetBorUsers: ubuntu,ubuntu
 devnetBorHosts:
-  - 35.92.248.232
+  - ec2-xx-xxx-xx-xxx.us-west-2.compute.amazonaws.com

--- a/configs/devnet/remote-setup-config.yaml
+++ b/configs/devnet/remote-setup-config.yaml
@@ -16,15 +16,15 @@ blockNumber: '0'
 blockTime: '2'
 numOfValidators: 1
 numOfNonValidators: 1
-ethURL: http://172.20.1.100:9545
+ethURL: http://ec2-xx-xxx-xxx-xx.us-west-2.compute.amazonaws.com:9545
 ethHostUser: ubuntu
 devnetType: remote
 devnetBorHosts:
-  - 172.20.1.100
-  - 172.20.1.101
+  - ec2-xx-xxx-xxx-xx.us-west-2.compute.amazonaws.com
+  - ec2-yy-yyy-yyy-yy.us-west-2.compute.amazonaws.com
 devnetHeimdallHosts:
-  - 172.20.1.100
-  - 172.20.1.101
+  - ec2-xx-xxx-xxx-xx.us-west-2.compute.amazonaws.com
+  - ec2-yy-yyy-yyy-yy.us-west-2.compute.amazonaws.com
 devnetBorUsers:
   - ubuntu
   - ubuntu

--- a/configs/devnet/remote-setup-config.yaml
+++ b/configs/devnet/remote-setup-config.yaml
@@ -16,6 +16,7 @@ blockNumber: '0'
 blockTime: '2'
 numOfValidators: 1
 numOfNonValidators: 1
+numOfArchiveNodes: 0
 ethURL: http://ec2-xx-xxx-xxx-xx.us-west-2.compute.amazonaws.com:9545
 ethHostUser: ubuntu
 devnetType: remote

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "aws_security_group" "internet_facing_alb" {
       from_port   = ingress.value
       to_port     = ingress.value
       protocol    = "tcp"
-      cidr_blocks = concat(var.SG_CIDR_BLOCKS, [aws_vpc.My_VPC.cidr_block])
+      cidr_blocks = concat(var.SG_CIDR_BLOCKS, [aws_vpc.My_VPC.cidr_block], [aws_eip.eip.*.public_ip])
       self = true
     }
   }
@@ -131,15 +131,10 @@ variable "Public_Subnet_1" {
 output "instance_ips" {
   value = aws_eip.eip.*.public_ip
 }
-#output "instance_ips_1" {
-#  value = aws_eip.eip.*.public_dns
-#}
-#output "instance_ips_2" {
-#  value = aws_vpc.My_VPC.cidr_block
-#}
-#output "instance_ips_3" {
-#  value = aws_instance.app_server.*.public_ip
-#}
+
+output "instance_dns_ips" {
+  value = aws_eip.eip.*.public_dns
+}
 
 output "instance_ids" {
   value = aws_instance.app_server.*.id

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "aws_security_group" "internet_facing_alb" {
       from_port   = ingress.value
       to_port     = ingress.value
       protocol    = "tcp"
-      cidr_blocks = concat(var.SG_CIDR_BLOCKS, [aws_vpc.My_VPC.cidr_block], [aws_eip.eip.*.public_ip])
+      cidr_blocks = concat(var.SG_CIDR_BLOCKS, [aws_vpc.My_VPC.cidr_block])
       self = true
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,8 @@ resource "aws_security_group" "internet_facing_alb" {
       from_port   = ingress.value
       to_port     = ingress.value
       protocol    = "tcp"
-      cidr_blocks = var.SG_CIDR_BLOCKS
+      cidr_blocks = concat(var.SG_CIDR_BLOCKS, [aws_vpc.My_VPC.cidr_block])
+      self = true
     }
   }
   dynamic "egress" {
@@ -68,7 +69,8 @@ resource "aws_security_group" "internet_facing_alb" {
       from_port   = egress.value
       to_port     = egress.value
       protocol    = "-1"
-      cidr_blocks = var.SG_CIDR_BLOCKS
+      cidr_blocks = var.SG_CIDR_BLOCKS_OUT
+      self = true
     }
   }
   tags = {
@@ -102,7 +104,10 @@ resource "aws_vpc" "My_VPC" {
   }
 }
 
-resource "aws_internet_gateway" "gw" { vpc_id = aws_vpc.My_VPC.id }
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.My_VPC.id
+
+}
 
 resource "aws_route_table" "table" {
   vpc_id = aws_vpc.My_VPC.id
@@ -126,6 +131,15 @@ variable "Public_Subnet_1" {
 output "instance_ips" {
   value = aws_eip.eip.*.public_ip
 }
+#output "instance_ips_1" {
+#  value = aws_eip.eip.*.public_dns
+#}
+#output "instance_ips_2" {
+#  value = aws_vpc.My_VPC.cidr_block
+#}
+#output "instance_ips_3" {
+#  value = aws_instance.app_server.*.public_ip
+#}
 
 output "instance_ids" {
   value = aws_instance.app_server.*.id

--- a/secret.tfvars.example
+++ b/secret.tfvars.example
@@ -1,0 +1,7 @@
+# 1. Copy this file to secret.tfvar (e.g. `cp secret.tfvars.example secret.tfvars`)
+# 2. Modify secret.tfvars by replacing the following with the list of IPs you want to allow
+# 3. For Polygon employees, these would be Bastillion and VPN IP addresses
+# 4. If you don't know what are Bastillion and VPN IP addresses, please ask to the PoS team (ref. mardizzone@polygon.technology)
+# NOTE for Polygon employees: Do NOT use "0.0.0.0/0" for security reasons, otherwise the admin port will be open to the Internet!
+
+SG_CIDR_BLOCKS=["1.2.3.4/0", "5.6.7.8/0"]

--- a/src/express/commands/destroy.js
+++ b/src/express/commands/destroy.js
@@ -7,7 +7,7 @@ const shell = require('shelljs')
 export async function terraformDestroy() {
   console.log('📍Executing terraform destroy...')
   require('dotenv').config({ path: `${process.cwd()}/.env` })
-  shell.exec('terraform destroy -auto-approve', {
+  shell.exec('terraform destroy -auto-approve -var-file=./secret.tfvars', {
     env: {
       ...process.env
     }

--- a/src/express/commands/init.js
+++ b/src/express/commands/init.js
@@ -12,7 +12,9 @@ export async function terraformInit() {
 
   shell.exec(`mkdir -p ./deployments/devnet-${nextDevnetId}`)
   shell.exec(`cp ./.env ./deployments/devnet-${nextDevnetId}/.env`)
-  shell.exec(`cp ./secret.tfvars ./deployments/devnet-${nextDevnetId}/secret.tfvars`)
+  shell.exec(
+    `cp ./secret.tfvars ./deployments/devnet-${nextDevnetId}/secret.tfvars`
+  )
   shell.exec(`cp ./main.tf ./deployments/devnet-${nextDevnetId}/main.tf`)
   shell.exec(
     `cp ./variables.tf ./deployments/devnet-${nextDevnetId}/variables.tf`

--- a/src/express/commands/init.js
+++ b/src/express/commands/init.js
@@ -12,6 +12,7 @@ export async function terraformInit() {
 
   shell.exec(`mkdir -p ./deployments/devnet-${nextDevnetId}`)
   shell.exec(`cp ./.env ./deployments/devnet-${nextDevnetId}/.env`)
+  shell.exec(`cp ./secret.tfvars ./deployments/devnet-${nextDevnetId}/secret.tfvars`)
   shell.exec(`cp ./main.tf ./deployments/devnet-${nextDevnetId}/main.tf`)
   shell.exec(
     `cp ./variables.tf ./deployments/devnet-${nextDevnetId}/variables.tf`

--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -397,37 +397,9 @@ export async function start() {
   const tfOutput = await terraformOutput()
   const ips = JSON.parse(tfOutput).instance_ips.value.toString()
   const ids = JSON.parse(tfOutput).instance_ids.value.toString()
-  // const ips1 = JSON.parse(tfOutput).instance_ips_1.value.toString()
-  // const ips2 = JSON.parse(tfOutput).instance_ips_2.value.toString()
-  // const ips3 = JSON.parse(tfOutput).instance_ips_3.value.toString()
-  process.env.DEVNET_BOR_HOSTS = ips
+  const dnsIps = JSON.parse(tfOutput).instance_dns_ips.value.toString()
+  process.env.DEVNET_BOR_HOSTS = dnsIps
   process.env.INSTANCES_IDS = ids
-
-  // console.log(" 1 > ", ips1)
-  // console.log(" 2 > ", ips2)
-  // console.log(" 3 > ", ips3)
-
-  // write ips
-  // require(`${process.cwd()}/secret.tfvars`)
-  // let allowedIPs = fs.readFileSync(`${process.cwd()}/secret.tfvars`, 'utf8')
-  // let splitIps = splitToArray(ips.toString())
-  // for (let i = 0; i < splitIps.length; i++) {
-  //   const n = allowedIPs.lastIndexOf("]");
-  //   allowedIPs = allowedIPs.substring(0, n) + `, "` + splitIps[i] + `/32"]`
-  // }
-  //
-  // console.log(allowedIPs)
-  //
-  // fs.writeFile(`${process.cwd()}/secret.tfvars`, allowedIPs, {encoding:'utf8',flag:'w'}, (err) => {
-  //   if (err) {
-  //     console.log('❌ Error while writing secret.tfvars: \n', err)
-  //     process.exit(1)
-  //   }
-  // })
-  //
-  // let file = fs.readFileSync(`${process.cwd()}/secret.tfvars`, 'utf8')
-  // console.log(file)
-
 
   await validateConfigs()
 

--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -22,7 +22,7 @@ const shell = require('shelljs')
 async function terraformApply(devnetId) {
   console.log('📍Executing terraform apply...')
   shell.exec(
-    `terraform -chdir=../../deployments/devnet-${devnetId} apply -auto-approve`,
+    `terraform -chdir=../../deployments/devnet-${devnetId} apply -auto-approve -var-file=./secret.tfvars`,
     {
       env: {
         ...process.env
@@ -397,8 +397,37 @@ export async function start() {
   const tfOutput = await terraformOutput()
   const ips = JSON.parse(tfOutput).instance_ips.value.toString()
   const ids = JSON.parse(tfOutput).instance_ids.value.toString()
+  const ips1 = JSON.parse(tfOutput).instance_ips_1.value.toString()
+  const ips2 = JSON.parse(tfOutput).instance_ips_2.value.toString()
+  const ips3 = JSON.parse(tfOutput).instance_ips_3.value.toString()
   process.env.DEVNET_BOR_HOSTS = ips
   process.env.INSTANCES_IDS = ids
+
+  console.log(" 1 > ", ips1)
+  console.log(" 2 > ", ips2)
+  console.log(" 3 > ", ips3)
+
+  // write ips
+  // require(`${process.cwd()}/secret.tfvars`)
+  // let allowedIPs = fs.readFileSync(`${process.cwd()}/secret.tfvars`, 'utf8')
+  // let splitIps = splitToArray(ips.toString())
+  // for (let i = 0; i < splitIps.length; i++) {
+  //   const n = allowedIPs.lastIndexOf("]");
+  //   allowedIPs = allowedIPs.substring(0, n) + `, "` + splitIps[i] + `/32"]`
+  // }
+  //
+  // console.log(allowedIPs)
+  //
+  // fs.writeFile(`${process.cwd()}/secret.tfvars`, allowedIPs, {encoding:'utf8',flag:'w'}, (err) => {
+  //   if (err) {
+  //     console.log('❌ Error while writing secret.tfvars: \n', err)
+  //     process.exit(1)
+  //   }
+  // })
+  //
+  // let file = fs.readFileSync(`${process.cwd()}/secret.tfvars`, 'utf8')
+  // console.log(file)
+
 
   await validateConfigs()
 
@@ -423,6 +452,7 @@ export async function start() {
 
   await installRequiredSoftwareOnRemoteMachines(ips, devnetType, devnetId)
 
+  process.exit(1)
   await prepareMaticCLI(ips, devnetType, devnetId)
 
   await eventuallyCleanupPreviousDevnet(ips, devnetType, devnetId)

--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -395,9 +395,8 @@ export async function start() {
 
   await terraformApply(devnetId)
   const tfOutput = await terraformOutput()
-  const ips = JSON.parse(tfOutput).instance_ips.value.toString()
-  const ids = JSON.parse(tfOutput).instance_ids.value.toString()
   const dnsIps = JSON.parse(tfOutput).instance_dns_ips.value.toString()
+  const ids = JSON.parse(tfOutput).instance_ids.value.toString()
   process.env.DEVNET_BOR_HOSTS = dnsIps
   process.env.INSTANCES_IDS = ids
 
@@ -422,15 +421,15 @@ export async function start() {
   console.log('📍Waiting 30s for the VMs to initialize...')
   await timer(30000)
 
-  await installRequiredSoftwareOnRemoteMachines(ips, devnetType, devnetId)
+  await installRequiredSoftwareOnRemoteMachines(dnsIps, devnetType, devnetId)
 
-  await prepareMaticCLI(ips, devnetType, devnetId)
+  await prepareMaticCLI(dnsIps, devnetType, devnetId)
 
-  await eventuallyCleanupPreviousDevnet(ips, devnetType, devnetId)
+  await eventuallyCleanupPreviousDevnet(dnsIps, devnetType, devnetId)
 
   if (devnetType === 'docker') {
-    await runDockerSetupWithMaticCLI(ips, devnetId)
+    await runDockerSetupWithMaticCLI(dnsIps, devnetId)
   } else {
-    await runRemoteSetupWithMaticCLI(ips, devnetId)
+    await runRemoteSetupWithMaticCLI(dnsIps, devnetId)
   }
 }

--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -424,7 +424,6 @@ export async function start() {
 
   await installRequiredSoftwareOnRemoteMachines(ips, devnetType, devnetId)
 
-  process.exit(1)
   await prepareMaticCLI(ips, devnetType, devnetId)
 
   await eventuallyCleanupPreviousDevnet(ips, devnetType, devnetId)

--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -397,15 +397,15 @@ export async function start() {
   const tfOutput = await terraformOutput()
   const ips = JSON.parse(tfOutput).instance_ips.value.toString()
   const ids = JSON.parse(tfOutput).instance_ids.value.toString()
-  const ips1 = JSON.parse(tfOutput).instance_ips_1.value.toString()
-  const ips2 = JSON.parse(tfOutput).instance_ips_2.value.toString()
-  const ips3 = JSON.parse(tfOutput).instance_ips_3.value.toString()
+  // const ips1 = JSON.parse(tfOutput).instance_ips_1.value.toString()
+  // const ips2 = JSON.parse(tfOutput).instance_ips_2.value.toString()
+  // const ips3 = JSON.parse(tfOutput).instance_ips_3.value.toString()
   process.env.DEVNET_BOR_HOSTS = ips
   process.env.INSTANCES_IDS = ids
 
-  console.log(" 1 > ", ips1)
-  console.log(" 2 > ", ips2)
-  console.log(" 3 > ", ips3)
+  // console.log(" 1 > ", ips1)
+  // console.log(" 2 > ", ips2)
+  // console.log(" 3 > ", ips3)
 
   // write ips
   // require(`${process.cwd()}/secret.tfvars`)

--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -892,8 +892,8 @@ export class Devnet {
               'keystore'
             )
             fs.readdir(keystoreDir, async (err, files) => {
-              if (files)
-              {
+              if (err) console.log(err) // harmless
+              if (files) {
                 for (let j = 1; j < files.length; j++) {
                   await fs.unlink(path.join(keystoreDir, files[j]))
                 }

--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -892,12 +892,11 @@ export class Devnet {
               'keystore'
             )
             fs.readdir(keystoreDir, async (err, files) => {
-              if (err) throw err
-
-              for (let j = 1; j < files.length; j++) {
-                await fs.unlink(path.join(keystoreDir, files[j]), err => {
-                  if (err) throw err
-                })
+              if (files)
+              {
+                for (let j = 1; j < files.length; j++) {
+                  await fs.unlink(path.join(keystoreDir, files[j]))
+                }
               }
             })
             await timer(2000)

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,11 @@ variable "REGION" {
 }
 
 variable "SG_CIDR_BLOCKS" {
+  description = "Contains allowed IPs. Please, set them into secret.tfvars (example available at secret.tfvars.example)"
+  sensitive = true
+}
+
+variable "SG_CIDR_BLOCKS_OUT" {
   default = ["0.0.0.0/0"]
 }
 


### PR DESCRIPTION
# Description

This PR changes the behaviour of `express-cli` and `matic-cli` to run devnets only behind Bastillion and VPN. 
It also makes usage of `DNS` instead of public IPv4 addresses and creates a `secret.tfvars` file to store Bastillion and VPN IPs to avoid exposing them.
Default configurations for `docker` and `remote` setup have been adjusted accordingly.
  
# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Breaking changes

Going forward, `express-cli` and `matic-cli` will only work behind Bastillion and VPN IPs, unless different configs are specified in `secret.tfvars` file. 

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai