### PR TITLE
add : added 'SignerChange' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ The `express-cli` also comes with additional utility commands, listed below. Som
 
   - Create a `StakeUpdate` transaction on the remote network and increase stake of 1st validator by 100 MATIC.
 
+- `../../bin/express-cli --send-signerchange-event`
+
+  - Create a `SignerChange` transaction on the remote network and changes the signer of the 1st validator.
+
 - ` ../../bin/express-cli --monitor [exit]`
 
   - Monitors the reception of state-syncs and checkpoints to make sure the whole network is in a healthy state.

--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -6,6 +6,7 @@ import { startStressTest } from './express/commands/stress'
 import { sendStateSyncTx } from './express/commands/send-state-sync'
 import { sendStakedEvent } from './express/commands/send-staked-event'
 import { sendStakeUpdateEvent } from './express/commands/send-stake-update'
+import { sendSignerChangeEvent } from './express/commands/send-signer-change'
 import { monitor } from './express/commands/monitor'
 import {
   restartAll,
@@ -66,6 +67,10 @@ program
   .option(
     '-sstakeupdate, --send-stakedupdate-event',
     'Send staked-update event'
+  )
+  .option(
+    '-ssignerchange, --send-signerchange-event',
+    'Send signer-change event'
   )
   .option(
     '-e1559, --eip-1559-test [index]',
@@ -284,6 +289,16 @@ export async function cli() {
     }
     await timer(3000)
     await sendStakeUpdateEvent()
+  } else if (options.sendSignerchangeEvent) {
+    console.log('📍Command --send-signerchange-event ')
+    if (!checkDir(false)) {
+      console.log(
+        '❌ The command is not called from the appropriate devnet directory!'
+      )
+      process.exit(1)
+    }
+    await timer(3000)
+    await sendSignerChangeEvent()
   } else if (options.eip1559Test) {
     console.log('📍Command --eip-1559-test')
     if (!checkDir(false)) {

--- a/src/express/commands/send-signer-change.js
+++ b/src/express/commands/send-signer-change.js
@@ -64,8 +64,17 @@ export async function sendSignerChangeEvent() {
   console.log('NewValidatorAddr', newAccAddr, newAccPubKey)
   console.log('NewValidatorPrivKey', wallet.getPrivateKeyString())
 
-  const tx = stakeManagerContract.methods.updateSigner(validatorIDForTest, newAccPubKey)
-  const signedTx = await getSignedTx(rootChainWeb3, StakeManagerProxyAddress, tx, validatorAccount, pkey)
+  const tx = stakeManagerContract.methods.updateSigner(
+    validatorIDForTest,
+    newAccPubKey
+  )
+  const signedTx = await getSignedTx(
+    rootChainWeb3,
+    StakeManagerProxyAddress,
+    tx,
+    validatorAccount,
+    pkey
+  )
   const Receipt = await rootChainWeb3.eth.sendSignedTransaction(
     signedTx.rawTransaction
   )

--- a/src/express/commands/send-staked-event.js
+++ b/src/express/commands/send-staked-event.js
@@ -6,6 +6,7 @@ import ERC20ABI from '../../abi/ERC20ABI.json'
 import Web3 from 'web3'
 import Wallet, { hdkey } from 'ethereumjs-wallet'
 import { timer } from '../common/time-utils'
+import { getSignedTx } from '../common/tx-utils'
 
 const {
   runScpCommand,
@@ -112,7 +113,7 @@ export async function sendStakedEvent() {
 
   while (parseInt(newValidatorsCount) !== parseInt(oldValidatorsCount) + 1) {
     console.log('Waiting 3 secs for validator to be added')
-    await timer(3000) // waiting 10 seconds for the validator to be added
+    await timer(3000) // waiting 3 secs
     newValidatorsCount = await checkValidatorsLength(doc)
     console.log('newValidatorsCount : ', newValidatorsCount)
   }
@@ -133,21 +134,4 @@ async function checkValidatorsLength(doc) {
   )
   const outobj = JSON.parse(out)
   return outobj.result.validators.length
-}
-
-async function getSignedTx(web3object, to, tx, validatorAccount, privateKey) {
-  const gas = await tx.estimateGas({ from: validatorAccount })
-  const data = tx.encodeABI()
-
-  const signedTx = await web3object.eth.accounts.signTransaction(
-    {
-      from: validatorAccount,
-      to,
-      data,
-      gas
-    },
-    privateKey
-  )
-
-  return signedTx
 }

--- a/src/express/common/tx-utils.js
+++ b/src/express/common/tx-utils.js
@@ -1,0 +1,16 @@
+export async function getSignedTx(web3object, to, tx, validatorAccount, privateKey) {
+  const gas = await tx.estimateGas({ from: validatorAccount })
+  const data = tx.encodeABI()
+
+  const signedTx = await web3object.eth.accounts.signTransaction(
+    {
+      from: validatorAccount,
+      to,
+      data,
+      gas
+    },
+    privateKey
+  )
+
+  return signedTx
+}

--- a/src/express/common/tx-utils.js
+++ b/src/express/common/tx-utils.js
@@ -1,4 +1,10 @@
-export async function getSignedTx(web3object, to, tx, validatorAccount, privateKey) {
+export async function getSignedTx(
+  web3object,
+  to,
+  tx,
+  validatorAccount,
+  privateKey
+) {
   const gas = await tx.estimateGas({ from: validatorAccount })
   const data = tx.encodeABI()
 


### PR DESCRIPTION
# Description

In this PR, we add a command `-ssignerchange` or `--send-signerchange-event` which changes the signer of the first validator to a newly created signer. 

It is a direct test if the `SignerChange` event is being bridged and processed on heimdall. 