### PR TITLE
add : added 'UnstakeInit' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ The `express-cli` also comes with additional utility commands, listed below. Som
 
   - Create a `SignerChange` transaction on the remote network and changes the signer of the 1st validator.
 
-- `../../bin/express-cli --send-unstakeinit-event`
+- `../../bin/express-cli --send-unstakeinit-event [validatorID]`
 
-  - Create a `UnstakeInit` transaction on the remote network and removes the validator from validator-set.
+  - Create a `UnstakeInit` transaction on the remote network and removes the validator from validator-set. `validatorID` can be used to specify the validator to be removed. If not specified, the first validator will be removed.
 
 - ` ../../bin/express-cli --monitor [exit]`
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ The `express-cli` also comes with additional utility commands, listed below. Som
 
   - Create a `SignerChange` transaction on the remote network and changes the signer of the 1st validator.
 
+- `../../bin/express-cli --send-unstakeinit-event`
+
+  - Create a `UnstakeInit` transaction on the remote network and removes the validator from validator-set.
+
 - ` ../../bin/express-cli --monitor [exit]`
 
   - Monitors the reception of state-syncs and checkpoints to make sure the whole network is in a healthy state.

--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -7,6 +7,7 @@ import { sendStateSyncTx } from './express/commands/send-state-sync'
 import { sendStakedEvent } from './express/commands/send-staked-event'
 import { sendStakeUpdateEvent } from './express/commands/send-stake-update'
 import { sendSignerChangeEvent } from './express/commands/send-signer-change'
+import { sendUnstakeInitEvent } from './express/commands/send-unstake-init'
 import { monitor } from './express/commands/monitor'
 import {
   restartAll,
@@ -71,6 +72,10 @@ program
   .option(
     '-ssignerchange, --send-signerchange-event',
     'Send signer-change event'
+  )
+  .option(
+    '-sunstakeinit, --send-unstakeinit-event',
+    'Send unstake-init event'
   )
   .option(
     '-e1559, --eip-1559-test [index]',
@@ -299,6 +304,16 @@ export async function cli() {
     }
     await timer(3000)
     await sendSignerChangeEvent()
+  } else if (options.sendUnstakeinitEvent) {
+    console.log('📍Command --send-unstakeinit-event ')
+    if (!checkDir(false)) {
+      console.log(
+        '❌ The command is not called from the appropriate devnet directory!'
+      )
+      process.exit(1)
+    }
+    await timer(3000)
+    await sendUnstakeInitEvent()
   } else if (options.eip1559Test) {
     console.log('📍Command --eip-1559-test')
     if (!checkDir(false)) {

--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -73,10 +73,7 @@ program
     '-ssignerchange, --send-signerchange-event',
     'Send signer-change event'
   )
-  .option(
-    '-sunstakeinit, --send-unstakeinit-event',
-    'Send unstake-init event'
-  )
+  .option('-sunstakeinit, --send-unstakeinit-event', 'Send unstake-init event')
   .option(
     '-e1559, --eip-1559-test [index]',
     'Test EIP 1559 txs. In case of a non-dockerized devnet, if an integer [index] is specified, it will use that VM to send the tx. Otherwise, it will target the first VM.'

--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -73,7 +73,10 @@ program
     '-ssignerchange, --send-signerchange-event',
     'Send signer-change event'
   )
-  .option('-sunstakeinit, --send-unstakeinit-event', 'Send unstake-init event')
+  .option(
+    '-sunstakeinit, --send-unstakeinit-event [validatorID]',
+    'Send unstake-init event'
+  )
   .option(
     '-e1559, --eip-1559-test [index]',
     'Test EIP 1559 txs. In case of a non-dockerized devnet, if an integer [index] is specified, it will use that VM to send the tx. Otherwise, it will target the first VM.'
@@ -302,15 +305,20 @@ export async function cli() {
     await timer(3000)
     await sendSignerChangeEvent()
   } else if (options.sendUnstakeinitEvent) {
-    console.log('📍Command --send-unstakeinit-event ')
+    console.log('📍Command --send-unstakeinit-event [validatorID]')
     if (!checkDir(false)) {
       console.log(
         '❌ The command is not called from the appropriate devnet directory!'
       )
       process.exit(1)
     }
+    if (options.sendUnstakeinitEvent === true) {
+      if (parseInt(options.sendUnstakeinitEvent) < 1) {
+        options.sendUnstakeinitEvent = 1
+      }
+    }
     await timer(3000)
-    await sendUnstakeInitEvent()
+    await sendUnstakeInitEvent(parseInt(options.sendUnstakeinitEvent))
   } else if (options.eip1559Test) {
     console.log('📍Command --eip-1559-test')
     if (!checkDir(false)) {

--- a/src/express/commands/send-staked-event.js
+++ b/src/express/commands/send-staked-event.js
@@ -124,7 +124,7 @@ export async function sendStakedEvent() {
   )
 }
 
-async function checkValidatorsLength(doc) {
+export async function checkValidatorsLength(doc) {
   const machine0 = doc.devnetBorHosts[0]
   const command = 'curl localhost:1317/staking/validator-set'
   const out = await runSshCommandWithReturn(

--- a/src/express/commands/send-unstake-init.js
+++ b/src/express/commands/send-unstake-init.js
@@ -9,7 +9,7 @@ import { checkValidatorsLength } from './send-staked-event'
 
 const { runScpCommand, maxRetries } = require('../common/remote-worker')
 
-export async function sendUnstakeInitEvent() {
+export async function sendUnstakeInitEvent(validatorID) {
   require('dotenv').config({ path: `${process.cwd()}/.env` })
   const devnetType =
     process.env.TF_VAR_DOCKERIZED === 'yes' ? 'docker' : 'remote'
@@ -18,6 +18,7 @@ export async function sendUnstakeInitEvent() {
 
   if (doc.devnetBorHosts.length > 0) {
     console.log('📍Monitoring the first node', doc.devnetBorHosts[0])
+    console.log('📍Unstaking Validator : ', validatorID)
   } else {
     console.log('📍No nodes to monitor, please check your configs! Exiting...')
     process.exit(1)
@@ -39,9 +40,9 @@ export async function sendUnstakeInitEvent() {
   const StakeManagerProxyAddress = contractAddresses.root.StakeManagerProxy
 
   const signerDump = require(`${process.cwd()}/signer-dump.json`)
-  const pkey = signerDump[0].priv_key
-  const validatorAccount = signerDump[0].address
-  const validatorIDForTest = '1'
+  const pkey = signerDump[validatorID - 1].priv_key
+  const validatorAccount = signerDump[validatorID - 1].address
+  const validatorIDForTest = validatorID.toString()
 
   const stakeManagerContract = new rootChainWeb3.eth.Contract(
     stakeManagerABI,

--- a/src/express/commands/send-unstake-init.js
+++ b/src/express/commands/send-unstake-init.js
@@ -1,0 +1,86 @@
+// noinspection JSUnresolvedVariable
+
+import { loadDevnetConfig } from '../common/config-utils'
+import stakeManagerABI from '../../abi/StakeManagerABI.json'
+import Web3 from 'web3'
+import { getSignedTx } from '../common/tx-utils'
+import { timer } from '../common/time-utils'
+import { checkValidatorsLength } from './send-staked-event'
+
+const {
+  runScpCommand,
+  maxRetries
+} = require('../common/remote-worker')
+
+export async function sendUnstakeInitEvent() {
+  require('dotenv').config({ path: `${process.cwd()}/.env` })
+  const devnetType =
+    process.env.TF_VAR_DOCKERIZED === 'yes' ? 'docker' : 'remote'
+
+  const doc = await loadDevnetConfig(devnetType)
+
+  if (doc.devnetBorHosts.length > 0) {
+    console.log('📍Monitoring the first node', doc.devnetBorHosts[0])
+  } else {
+    console.log('📍No nodes to monitor, please check your configs! Exiting...')
+    process.exit(1)
+  }
+
+  const machine0 = doc.devnetBorHosts[0]
+  const rootChainWeb3 = new Web3(`http://${machine0}:9545`)
+
+  let src = `${doc.ethHostUser}@${machine0}:~/matic-cli/devnet/devnet/signer-dump.json`
+  let dest = './signer-dump.json'
+  await runScpCommand(src, dest, maxRetries)
+
+  src = `${doc.ethHostUser}@${machine0}:~/matic-cli/devnet/code/contracts/contractAddresses.json`
+  dest = './contractAddresses.json'
+  await runScpCommand(src, dest, maxRetries)
+
+  const contractAddresses = require(`${process.cwd()}/contractAddresses.json`)
+
+  const StakeManagerProxyAddress = contractAddresses.root.StakeManagerProxy
+
+  const signerDump = require(`${process.cwd()}/signer-dump.json`)
+  const pkey = signerDump[0].priv_key
+  const validatorAccount = signerDump[0].address
+  const validatorIDForTest = '1'
+
+  const stakeManagerContract = new rootChainWeb3.eth.Contract(
+    stakeManagerABI,
+    StakeManagerProxyAddress
+  )
+
+  const tx = stakeManagerContract.methods.unstake(
+    validatorIDForTest
+  )
+  const signedTx = await getSignedTx(
+    rootChainWeb3,
+    StakeManagerProxyAddress,
+    tx,
+    validatorAccount,
+    pkey
+  )
+
+  const oldValidatorsCount = await checkValidatorsLength(doc)
+  console.log('oldValidatorsCount : ', oldValidatorsCount)
+
+  const Receipt = await rootChainWeb3.eth.sendSignedTransaction(
+    signedTx.rawTransaction
+  )
+  console.log('Unstake Receipt', Receipt.transactionHash)
+
+  let newValidatorsCount = await checkValidatorsLength(doc)
+
+  while (parseInt(newValidatorsCount) !== parseInt(oldValidatorsCount) - 1) {
+    console.log('Waiting 3 secs for validator to be removed')
+    await timer(3000) // waiting 3 secs
+    newValidatorsCount = await checkValidatorsLength(doc)
+    console.log('newValidatorsCount : ', newValidatorsCount)
+  }
+
+  console.log('✅ Validator Unstake Done')
+  console.log(
+    '✅ UnstakeInit Event Sent from Rootchain and Received and processed on Heimdall'
+  )
+}

--- a/src/express/commands/send-unstake-init.js
+++ b/src/express/commands/send-unstake-init.js
@@ -7,10 +7,7 @@ import { getSignedTx } from '../common/tx-utils'
 import { timer } from '../common/time-utils'
 import { checkValidatorsLength } from './send-staked-event'
 
-const {
-  runScpCommand,
-  maxRetries
-} = require('../common/remote-worker')
+const { runScpCommand, maxRetries } = require('../common/remote-worker')
 
 export async function sendUnstakeInitEvent() {
   require('dotenv').config({ path: `${process.cwd()}/.env` })
@@ -51,9 +48,7 @@ export async function sendUnstakeInitEvent() {
     StakeManagerProxyAddress
   )
 
-  const tx = stakeManagerContract.methods.unstake(
-    validatorIDForTest
-  )
+  const tx = stakeManagerContract.methods.unstake(validatorIDForTest)
   const signedTx = await getSignedTx(
     rootChainWeb3,
     StakeManagerProxyAddress,


### PR DESCRIPTION
# Description

In this PR, we add a command `-sunstakeinit` or `--send-unstakeinit-event` which removes validator from the validator-set. 

It is a direct test if the `UnstakeInit` event is being bridged and processed on heimdall. 