### PR TITLE
add : worker* metrics in openmetrics-conf

### DIFF
--- a/configs/devnet/openmetrics-conf.yaml
+++ b/configs/devnet/openmetrics-conf.yaml
@@ -10,6 +10,7 @@ instances:
       - les*
       - eth*
       - chain*
+      - worker*
     namespace: bor
     openmetrics_endpoint: http://localhost:7071/debug/metrics/prometheus
   - exclude_metrics:


### PR DESCRIPTION
# Description

In this PR, we add `worker*` metrics to be sent to Datadog via `openmetrics-conf.yaml`
