### PR TITLE
dev: fix: rm folders with sudo privileges

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ TF_VAR_DISK_SIZE_GB=100# size of the disk in GB (default is 100GB)
 TF_VAR_ARCHIVE_DISK_SIZE_GB=100 # size of the disk in GB in archive node (default is 100GB)
 TF_VAR_IOPS=3000# Amount of provisioned IOPS
 TF_VAR_ARCHIVE_IOPS=15000 # Amount of provisioned IOPS in archive node
-TF_VAR_VALIDATOR_COUNT=2# number of validator nodes (default is 2). Note that while spinning up a public network (mainnet/mumbai) node, this will serve as a non-validator
+TF_VAR_VALIDATOR_COUNT=2# number of validator nodes (default is 2)
 TF_VAR_SENTRY_COUNT=1# number of non-validator sentry nodes (default is 1)
 TF_VAR_ARCHIVE_COUNT=0 # number of archive nodes (default is 0)
 TF_VAR_INSTANCE_TYPE=t2.xlarge# type of the EC2 VM instance (default is t2.xlarge)
@@ -21,8 +21,6 @@ PEM_FILE_PATH=/absolute/path/to/your/aws-key.pem# absolute path pointing to the 
 # Polygon network based variables (see configs/README.md) for more detailed info
 DEFAULT_STAKE=10000# default stake for each validator (in matic)
 DEFAULT_FEE=2000# default amount of fee to topup heimdall validator
-NETWORK= # mention "mumbai", "mainnet" or leave empty if spinning up a local devnet
-HEIMDALL_SEEDS=4cd60c1d76e44b05f7dfd8bab3f447b119e87042@54.147.31.250:26656,b18bbe1f3d8576f4b73d9b18976e71c65e839149@34.226.134.117:26656 # Heimdall seeds to be added in config.toml (when running a mainnet/mumbai node )
 BOR_CHAIN_ID= # bor chainID (leave empty to get a random one)
 HEIMDALL_CHAIN_ID= # heimdall chainID (leave empty to get a random one)
 SPRINT_SIZE=64 # sprint size (number of blocks for each bor sprint)
@@ -45,10 +43,6 @@ HEIMDALL_DOCKER_BUILD_CONTEXT="https://github.com/maticnetwork/heimdall.git#deve
 VERBOSE=true# if set to true will print logs also from remote machines
 DD_API_KEY=DATADOG_API_KEY# Datadog API key
 
-# Bor and Heimdall Snapshot related variables (when running mainnet/testnet node)
-BOR_SNAPSHOT_URL=https://snapshot-download.polygon.technology/bor-mumbai-fullnode-2023-03-18.tar.zst # URL for bor data snapshot (refer: https://snapshot.polygon.technology/)
-HEIMDALL_SNAPSHOT_URL=https://snapshot-download.polygon.technology/heimdall-mumbai-fullnode-2023-03-18.tar.zst # URL for heimdall data snapshot (refer: https://snapshot.polygon.technology/)
-
 #Stress test variables (used to run stress tests against the remote nodes)
 MNEMONIC="clock radar mass judge dismiss just intact mind resemble fringe diary casino" #random mnemonic
 SPEED=200# TPS = ~2 * SPEED (Default SPEED = 200; TPS = ~400)
@@ -61,6 +55,3 @@ BURN_CONTRACT_ADDRESS=0x000000000000000000000000000000000000dead# Burn contract 
 MAX_FEE=30000000009# Max fee per gas
 MAX_PRIORITY_FEE=30000000000# Max priority fee per gas
 COUNT=10# Number of times to execute the test
-
-#Shadow fork related variables
-SHADOW_CHAIN_ID= #Chain Id of the shadow node (leave empty to get random one)

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ TF_VAR_DISK_SIZE_GB=100# size of the disk in GB (default is 100GB)
 TF_VAR_ARCHIVE_DISK_SIZE_GB=100 # size of the disk in GB in archive node (default is 100GB)
 TF_VAR_IOPS=3000# Amount of provisioned IOPS
 TF_VAR_ARCHIVE_IOPS=15000 # Amount of provisioned IOPS in archive node
-TF_VAR_VALIDATOR_COUNT=2# number of validator nodes (default is 2)
+TF_VAR_VALIDATOR_COUNT=2# number of validator nodes (default is 2). Note that while spinning up a public network (mainnet/mumbai) node, this will serve as a non-validator
 TF_VAR_SENTRY_COUNT=1# number of non-validator sentry nodes (default is 1)
 TF_VAR_ARCHIVE_COUNT=0 # number of archive nodes (default is 0)
 TF_VAR_INSTANCE_TYPE=t2.xlarge# type of the EC2 VM instance (default is t2.xlarge)
@@ -21,6 +21,8 @@ PEM_FILE_PATH=/absolute/path/to/your/aws-key.pem# absolute path pointing to the 
 # Polygon network based variables (see configs/README.md) for more detailed info
 DEFAULT_STAKE=10000# default stake for each validator (in matic)
 DEFAULT_FEE=2000# default amount of fee to topup heimdall validator
+NETWORK= # mention "mumbai", "mainnet" or leave empty if spinning up a local devnet
+HEIMDALL_SEEDS=4cd60c1d76e44b05f7dfd8bab3f447b119e87042@54.147.31.250:26656,b18bbe1f3d8576f4b73d9b18976e71c65e839149@34.226.134.117:26656 # Heimdall seeds to be added in config.toml (when running a mainnet/mumbai node )
 BOR_CHAIN_ID= # bor chainID (leave empty to get a random one)
 HEIMDALL_CHAIN_ID= # heimdall chainID (leave empty to get a random one)
 SPRINT_SIZE=64 # sprint size (number of blocks for each bor sprint)
@@ -43,6 +45,10 @@ HEIMDALL_DOCKER_BUILD_CONTEXT="https://github.com/maticnetwork/heimdall.git#deve
 VERBOSE=true# if set to true will print logs also from remote machines
 DD_API_KEY=DATADOG_API_KEY# Datadog API key
 
+# Bor and Heimdall Snapshot related variables (when running mainnet/testnet node)
+BOR_SNAPSHOT_URL=https://snapshot-download.polygon.technology/bor-mumbai-fullnode-2023-03-18.tar.zst # URL for bor data snapshot (refer: https://snapshot.polygon.technology/)
+HEIMDALL_SNAPSHOT_URL=https://snapshot-download.polygon.technology/heimdall-mumbai-fullnode-2023-03-18.tar.zst # URL for heimdall data snapshot (refer: https://snapshot.polygon.technology/)
+
 #Stress test variables (used to run stress tests against the remote nodes)
 MNEMONIC="clock radar mass judge dismiss just intact mind resemble fringe diary casino" #random mnemonic
 SPEED=200# TPS = ~2 * SPEED (Default SPEED = 200; TPS = ~400)
@@ -55,3 +61,6 @@ BURN_CONTRACT_ADDRESS=0x000000000000000000000000000000000000dead# Burn contract 
 MAX_FEE=30000000009# Max fee per gas
 MAX_PRIORITY_FEE=30000000000# Max priority fee per gas
 COUNT=10# Number of times to execute the test
+
+#Shadow fork related variables
+SHADOW_CHAIN_ID= #Chain Id of the shadow node (leave empty to get random one)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maticnetwork/matic-cli",
-  "version": "0.0.9",
+  "version": "0.10.0",
   "description": "Testing toolkit to setup, manage and operate Polygon networks",
   "publishConfig": {
     "access": "public"

--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -244,7 +244,7 @@ async function eventuallyCleanupPreviousDevnet(ips, devnetType, devnetId) {
       console.log(
         '📍Removing old devnet (if present) on machine ' + ip + ' ...'
       )
-      let command = 'rm -rf ~/matic-cli/devnet'
+      let command = 'sudo rm -rf ~/matic-cli/devnet'
       await runSshCommand(ip, command, maxRetries)
 
       console.log('📍Stopping ganache (if present) on machine ' + ip + ' ...')
@@ -263,7 +263,7 @@ async function eventuallyCleanupPreviousDevnet(ips, devnetType, devnetId) {
     await runSshCommand(ip, command, maxRetries)
 
     console.log('📍Removing .bor folder (if present) on machine ' + ip + ' ...')
-    command = 'rm -rf ~/.bor'
+    command = 'sudo rm -rf ~/.bor'
     await runSshCommand(ip, command, maxRetries)
 
     console.log(
@@ -271,15 +271,15 @@ async function eventuallyCleanupPreviousDevnet(ips, devnetType, devnetId) {
         ip +
         ' ...'
     )
-    command = 'rm -rf /var/lib/heimdall'
+    command = 'sudo rm -rf /var/lib/heimdall'
     await runSshCommand(ip, command, maxRetries)
 
     console.log('📍Removing data folder (if present) on machine ' + ip + ' ...')
-    command = 'rm -rf ~/data'
+    command = 'sudo rm -rf ~/data'
     await runSshCommand(ip, command, maxRetries)
 
     console.log('📍Removing node folder (if present) on machine ' + ip + ' ...')
-    command = 'rm -rf ~/node'
+    command = 'sudo rm -rf ~/node'
     await runSshCommand(ip, command, maxRetries)
   })
 


### PR DESCRIPTION
# Description

This PR fixes behaviour of `rm -rf` by running it with sudo privileges.
Also, it updates the snapshots URLs of bor and heimdall

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
