### PR TITLE
dev: chg: continue on error when uploading snyk results to GH

### DIFF
--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -15,10 +15,6 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --org=${{ secrets.SNYK_ORG }} --severity-threshold=medium --sarif-file-output=snyk.sarif
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: snyk.sarif
 
   snyk-code:
     name: Snyk Code and Publish
@@ -35,7 +31,3 @@ jobs:
         with:
           args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
           command: code test
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: snyk.sarif

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -15,6 +15,11 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --org=${{ secrets.SNYK_ORG }} --severity-threshold=medium --sarif-file-output=snyk.sarif
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        continue-on-error: true
+        with:
+          sarif_file: snyk.sarif
 
   snyk-code:
     name: Snyk Code and Publish
@@ -31,3 +36,8 @@ jobs:
         with:
           args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
           command: code test
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        continue-on-error: true
+        with:
+          sarif_file: snyk.sarif


### PR DESCRIPTION
# Description

Given the GH license changes and `snyk` integration, we are not throwing errors when `snyk` report upload to GH fails 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai