### PR TITLE
dev: add: POS-1366: parametrize smart contracts e2e tests to use validatorID as argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,9 @@ jobs:
       - name: Run smart contracts events tests
         run: |
           cd matic-cli/deployments/devnet-1
-          timeout 5m ../../bin/express-cli --send-staked-event
-          timeout 5m ../../bin/express-cli --send-stakeupdate-event
-          timeout 5m ../../bin/express-cli --send-topupfee-event
+          timeout 5m ../../bin/express-cli --send-staked-event 1
+          timeout 5m ../../bin/express-cli --send-stakeupdate-event 1
+          timeout 5m ../../bin/express-cli --send-topupfee-event 1
           timeout 10m ../../bin/express-cli --send-unstakeinit-event 1
 
       - name: Destroy devnet

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maticnetwork/matic-cli",
-  "version": "0.0.9",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maticnetwork/matic-cli",
-      "version": "0.0.9",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@truffle/hdwallet-provider": "^2.1.4",
@@ -21,6 +21,7 @@
         "esm": "^3.2.18",
         "eth-crypto": "^2.4.0",
         "ethereumjs-util": "^7.1.5",
+        "ethereumjs-wallet": "^1.0.2",
         "execa": "^1.0.0",
         "fs-extra": "^10.1.0",
         "ganache": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "esm": "^3.2.18",
     "eth-crypto": "^2.4.0",
     "ethereumjs-util": "^7.1.5",
+    "ethereumjs-wallet": "^1.0.2",
     "execa": "^1.0.0",
     "fs-extra": "^10.1.0",
     "ganache": "^7.5.0",

--- a/src/express-cli.js
+++ b/src/express-cli.js
@@ -67,13 +67,19 @@ program
     'Start the stress test. If the string `fund` is specified, the account will be funded. This option is mandatory when the command is executed the first time on a devnet.'
   )
   .option('-ss, --send-state-sync', 'Send state sync tx')
-  .option('-sstake, --send-staked-event', 'Send staked event')
-  .option('-sstakeupdate, --send-stakeupdate-event', 'Send staked-update event')
+  .option('-sstake, --send-staked-event [validatorID]', 'Send staked event')
   .option(
-    '-ssignerchange, --send-signerchange-event',
+    '-sstakeupdate, --send-stakeupdate-event [validatorID]',
+    'Send staked-update event'
+  )
+  .option(
+    '-ssignerchange, --send-signerchange-event [validatorID]',
     'Send signer-change event'
   )
-  .option('-stopupfee, --send-topupfee-event', 'Send topupfee event')
+  .option(
+    '-stopupfee, --send-topupfee-event [validatorID]',
+    'Send topupfee event'
+  )
   .option(
     '-sunstakeinit, --send-unstakeinit-event [validatorID]',
     'Send unstake-init event'
@@ -287,7 +293,7 @@ export async function cli() {
     await timer(3000)
     await sendStateSyncTx()
   } else if (options.sendStakedEvent) {
-    console.log('📍Command --send-staked-event ')
+    console.log('📍Command --send-staked-event [validatorID]')
     if (!checkDir(false)) {
       console.log(
         '❌ The command is not called from the appropriate devnet directory!'
@@ -295,9 +301,9 @@ export async function cli() {
       process.exit(1)
     }
     await timer(3000)
-    await sendStakedEvent()
+    await sendStakedEvent(options.sendStakedEvent)
   } else if (options.sendStakeupdateEvent) {
-    console.log('📍Command --send-stakeupdate-event ')
+    console.log('📍Command --send-stakeupdate-event [validatorID]')
     if (!checkDir(false)) {
       console.log(
         '❌ The command is not called from the appropriate devnet directory!'
@@ -305,9 +311,9 @@ export async function cli() {
       process.exit(1)
     }
     await timer(3000)
-    await sendStakeUpdateEvent()
+    await sendStakeUpdateEvent(options.sendStakeupdateEvent)
   } else if (options.sendSignerchangeEvent) {
-    console.log('📍Command --send-signerchange-event ')
+    console.log('📍Command --send-signerchange-event [validatorID]')
     if (!checkDir(false)) {
       console.log(
         '❌ The command is not called from the appropriate devnet directory!'
@@ -315,7 +321,7 @@ export async function cli() {
       process.exit(1)
     }
     await timer(3000)
-    await sendSignerChangeEvent()
+    await sendSignerChangeEvent(options.sendSignerchangeEvent)
   } else if (options.sendUnstakeinitEvent) {
     console.log('📍Command --send-unstakeinit-event [validatorID]')
     if (!checkDir(false)) {
@@ -324,15 +330,10 @@ export async function cli() {
       )
       process.exit(1)
     }
-    if (options.sendUnstakeinitEvent === true) {
-      if (parseInt(options.sendUnstakeinitEvent) < 1) {
-        options.sendUnstakeinitEvent = 1
-      }
-    }
     await timer(3000)
-    await sendUnstakeInitEvent(parseInt(options.sendUnstakeinitEvent))
+    await sendUnstakeInitEvent(options.sendUnstakeinitEvent)
   } else if (options.sendTopupfeeEvent) {
-    console.log('📍Command --send-topupfee-event ')
+    console.log('📍Command --send-topupfee-event [validatorID]')
     if (!checkDir(false)) {
       console.log(
         '❌ The command is not called from the appropriate devnet directory!'
@@ -340,7 +341,7 @@ export async function cli() {
       process.exit(1)
     }
     await timer(3000)
-    await sendTopUpFeeEvent()
+    await sendTopUpFeeEvent(options.sendTopupfeeEvent)
   } else if (options.eip1559Test) {
     console.log('📍Command --eip-1559-test')
     if (!checkDir(false)) {

--- a/src/express/commands/send-stake-update.js
+++ b/src/express/commands/send-stake-update.js
@@ -1,11 +1,10 @@
-// noinspection JSUnresolvedVariable
-
 import { loadDevnetConfig } from '../common/config-utils'
 import stakeManagerABI from '../../abi/StakeManagerABI.json'
 import ERC20ABI from '../../abi/ERC20ABI.json'
 import Web3 from 'web3'
 import { timer } from '../common/time-utils'
 import { getSignedTx } from '../common/tx-utils'
+import { isValidatorIdCorrect } from '../common/validators-utils'
 
 const {
   runScpCommand,
@@ -13,19 +12,27 @@ const {
   maxRetries
 } = require('../common/remote-worker')
 
-export async function sendStakeUpdateEvent() {
+export async function sendStakeUpdateEvent(validatorID) {
   require('dotenv').config({ path: `${process.cwd()}/.env` })
   const devnetType =
     process.env.TF_VAR_DOCKERIZED === 'yes' ? 'docker' : 'remote'
 
   const doc = await loadDevnetConfig(devnetType)
 
+  if (!isValidatorIdCorrect(validatorID, doc.devnetBorHosts.length)) {
+    console.log(
+      '📍Invalid validatorID used, please try with a valid argument! Exiting...'
+    )
+    process.exit(1)
+  }
   if (doc.devnetBorHosts.length > 0) {
     console.log('📍Monitoring the first node', doc.devnetBorHosts[0])
   } else {
     console.log('📍No nodes to monitor, please check your configs! Exiting...')
     process.exit(1)
   }
+
+  validatorID = Number(validatorID)
 
   const machine0 = doc.devnetBorHosts[0]
   const rootChainWeb3 = new Web3(`http://${machine0}:9545`)
@@ -49,9 +56,8 @@ export async function sendStakeUpdateEvent() {
   )
 
   const signerDump = require(`${process.cwd()}/signer-dump.json`)
-  const pkey = signerDump[0].priv_key
-  const validatorAccount = signerDump[0].address
-  const validatorIDForTest = '1'
+  const pkey = signerDump[validatorID - 1].priv_key
+  const validatorAccount = signerDump[validatorID - 1].address
 
   const stakeManagerContract = new rootChainWeb3.eth.Contract(
     stakeManagerABI,
@@ -76,12 +82,12 @@ export async function sendStakeUpdateEvent() {
     '\n\nApproval Receipt txHash:  ' + approvalReceipt.transactionHash
   )
 
-  const oldValidatarPower = await getValidatorPower(doc, validatorIDForTest)
-  console.log('Old Validator Power:  ' + oldValidatarPower)
+  const oldValidatorPower = await getValidatorPower(doc, validatorID)
+  console.log('Old Validator Power:  ' + oldValidatorPower)
 
   // Adding 100 MATIC stake
   tx = stakeManagerContract.methods.restake(
-    validatorIDForTest,
+    validatorID,
     rootChainWeb3.utils.toWei('100'),
     false
   )
@@ -97,18 +103,18 @@ export async function sendStakeUpdateEvent() {
   )
   console.log('Restake Receipt txHash:  ' + Receipt.transactionHash)
 
-  let newValidatarPower = await getValidatorPower(doc, validatorIDForTest)
+  let newValidatorPower = await getValidatorPower(doc, validatorID)
 
-  while (parseInt(newValidatarPower) !== parseInt(oldValidatarPower) + 100) {
+  while (parseInt(newValidatorPower) !== parseInt(oldValidatorPower) + 100) {
     console.log('Waiting 3 secs for stakeupdate')
     await timer(3000) // waiting 3 secs
-    newValidatarPower = await getValidatorPower(doc, validatorIDForTest)
-    console.log('newValidatarPower : ', newValidatarPower)
+    newValidatorPower = await getValidatorPower(doc, validatorID)
+    console.log('newValidatorPower : ', newValidatorPower)
   }
 
   console.log('✅ Stake Updated')
   console.log(
-    '✅ Stake-Update event Sent from Rootchain and Received and processed on Heimdall'
+    '✅ Stake-Update event sent from rootchain, received and processed on Heimdall'
   )
 }
 
@@ -120,6 +126,6 @@ async function getValidatorPower(doc, validatorID) {
     command,
     maxRetries
   )
-  const outobj = JSON.parse(out)
-  return outobj.result.power
+  const outObj = JSON.parse(out)
+  return outObj.result.power
 }

--- a/src/express/commands/send-unstake-init.js
+++ b/src/express/commands/send-unstake-init.js
@@ -6,6 +6,7 @@ import Web3 from 'web3'
 import { getSignedTx } from '../common/tx-utils'
 import { timer } from '../common/time-utils'
 import { checkValidatorsLength } from './send-staked-event'
+import { isValidatorIdCorrect } from '../common/validators-utils'
 
 const { runScpCommand, maxRetries } = require('../common/remote-worker')
 
@@ -16,6 +17,12 @@ export async function sendUnstakeInitEvent(validatorID) {
 
   const doc = await loadDevnetConfig(devnetType)
 
+  if (!isValidatorIdCorrect(validatorID, doc.devnetBorHosts.length)) {
+    console.log(
+      '📍Invalid validatorID used, please try with a valid argument! Exiting...'
+    )
+    process.exit(1)
+  }
   if (doc.devnetBorHosts.length > 0) {
     console.log('📍Monitoring the first node', doc.devnetBorHosts[0])
     console.log('📍Unstaking Validator : ', validatorID)
@@ -23,6 +30,8 @@ export async function sendUnstakeInitEvent(validatorID) {
     console.log('📍No nodes to monitor, please check your configs! Exiting...')
     process.exit(1)
   }
+
+  validatorID = Number(validatorID)
 
   const machine0 = doc.devnetBorHosts[0]
   const rootChainWeb3 = new Web3(`http://${machine0}:9545`)

--- a/src/express/common/validators-utils.js
+++ b/src/express/common/validators-utils.js
@@ -1,0 +1,9 @@
+export function isValidatorIdCorrect(id, validatorsLength) {
+  return (
+    id !== null &&
+    id !== undefined &&
+    typeof id !== 'boolean' &&
+    Number(id) > 0 &&
+    Number(id) <= validatorsLength
+  )
+}


### PR DESCRIPTION
# Description

With this PR, e2e smart contracts tests can be executed given a certain `validatorID` as argument

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai