### PR TITLE
Do not exit on services not running or not configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Init devnet
         run: |
           cd matic-cli
-          ./bin/express-cli --init
+          ./bin/express-cli --init aws
 
       - name: Start devnet
         run: |

--- a/src/express/commands/cleanup.js
+++ b/src/express/commands/cleanup.js
@@ -65,15 +65,15 @@ export async function stopServices(doc) {
 
     if (hostToIndexMap.get(ip) < returnTotalBorNodes(doc)) {
       console.log('📍Stopping bor on machine ' + ip + ' ...')
-      command = 'sudo systemctl stop bor.service'
+      command = 'sudo systemctl stop bor.service || echo "bor not running on current machine..."'
       await runSshCommand(ip, command, maxRetries)
     } else {
       console.log('📍Stopping erigon on machine ' + ip + ' ...')
-      command = 'sudo systemctl stop erigon.service'
+      command = 'sudo systemctl stop erigon.service || echo "erigon not running on current machine..."'
       await runSshCommand(ip, command, maxRetries)
     }
     console.log('📍Stopping heimdall on machine ' + ip + '...')
-    command = 'sudo systemctl stop heimdalld.service'
+    command = 'sudo systemctl stop heimdalld.service || echo "heimdall not running on current machine..."'
     await runSshCommand(ip, command, maxRetries)
   })
 

--- a/src/express/commands/cleanup.js
+++ b/src/express/commands/cleanup.js
@@ -65,15 +65,18 @@ export async function stopServices(doc) {
 
     if (hostToIndexMap.get(ip) < returnTotalBorNodes(doc)) {
       console.log('📍Stopping bor on machine ' + ip + ' ...')
-      command = 'sudo systemctl stop bor.service || echo "bor not running on current machine..."'
+      command =
+        'sudo systemctl stop bor.service || echo "bor not running on current machine..."'
       await runSshCommand(ip, command, maxRetries)
     } else {
       console.log('📍Stopping erigon on machine ' + ip + ' ...')
-      command = 'sudo systemctl stop erigon.service || echo "erigon not running on current machine..."'
+      command =
+        'sudo systemctl stop erigon.service || echo "erigon not running on current machine..."'
       await runSshCommand(ip, command, maxRetries)
     }
     console.log('📍Stopping heimdall on machine ' + ip + '...')
-    command = 'sudo systemctl stop heimdalld.service || echo "heimdall not running on current machine..."'
+    command =
+      'sudo systemctl stop heimdalld.service || echo "heimdall not running on current machine..."'
     await runSshCommand(ip, command, maxRetries)
   })
 

--- a/src/express/commands/update.js
+++ b/src/express/commands/update.js
@@ -47,7 +47,7 @@ export async function pullAndRestartBor(ip, i, isPull) {
   }
 
   console.log('📍Starting bor...')
-  command = 'sudo systemctl start bor.service'
+  command = 'sudo systemctl start bor.service || echo "bor not configured on current machine..."'
   await runSshCommand(ip, command, maxRetries)
 }
 
@@ -94,7 +94,7 @@ export async function pullAndRestartErigon(ip, i, isPull, erigonHostsLength) {
   }
 
   console.log('📍Starting erigon...')
-  command = 'sudo systemctl start erigon.service'
+  command = 'sudo systemctl start erigon.service || echo "erigon not configured on current machine..."'
   await runSshCommand(ip, command, maxRetries)
 }
 
@@ -145,7 +145,7 @@ export async function pullAndRestartHeimdall(doc, ip, i, isPull) {
   }
 
   console.log('📍Starting heimdall...')
-  command = 'sudo systemctl start heimdalld.service'
+  command = 'sudo systemctl start heimdalld.service || echo "heimdall not configured on current machine..."'
   await runSshCommand(ip, command, maxRetries)
 }
 

--- a/src/express/commands/update.js
+++ b/src/express/commands/update.js
@@ -47,7 +47,8 @@ export async function pullAndRestartBor(ip, i, isPull) {
   }
 
   console.log('📍Starting bor...')
-  command = 'sudo systemctl start bor.service || echo "bor not configured on current machine..."'
+  command =
+    'sudo systemctl start bor.service || echo "bor not configured on current machine..."'
   await runSshCommand(ip, command, maxRetries)
 }
 
@@ -94,7 +95,8 @@ export async function pullAndRestartErigon(ip, i, isPull, erigonHostsLength) {
   }
 
   console.log('📍Starting erigon...')
-  command = 'sudo systemctl start erigon.service || echo "erigon not configured on current machine..."'
+  command =
+    'sudo systemctl start erigon.service || echo "erigon not configured on current machine..."'
   await runSshCommand(ip, command, maxRetries)
 }
 
@@ -145,7 +147,8 @@ export async function pullAndRestartHeimdall(doc, ip, i, isPull) {
   }
 
   console.log('📍Starting heimdall...')
-  command = 'sudo systemctl start heimdalld.service || echo "heimdall not configured on current machine..."'
+  command =
+    'sudo systemctl start heimdalld.service || echo "heimdall not configured on current machine..."'
   await runSshCommand(ip, command, maxRetries)
 }
 


### PR DESCRIPTION
# Description

In this PR, we fix the behaviour of `express-cli` to avoid `process.exit` when the services (bor, heimdall or erigon) are not running or are not configured on the VMs.
 
# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai