### PR TITLE
add : use chain name for heimdalld service when using mainnet/mumbai

### DIFF
--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -746,6 +746,17 @@ export class Devnet {
                             'sudo mv ~/bor.service /lib/systemd/system/'
             ], { stdio: getRemoteStdio() })
 
+            if (this.config.network) {
+              const chain = this.config.network
+              await execa('ssh', [
+                '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null',
+                '-i', '~/cert.pem',
+                      `${this.config.devnetBorUsers[i]}@${this.config.devnetBorHosts[i]}`,
+                      // eslint-disable-next-line
+                      `sed -i "s|\\/var/lib/heimdall/config/genesis.json|${chain}|g" ~/heimdalld.service`
+              ], { stdio: getRemoteStdio() })
+            }
+
             await execa(
               'ssh',
               [


### PR DESCRIPTION
In this PR, we will use `--chain=mainnet` or `--chain=mumbai` instead of `--chain=genesis.json` to have better predictability that the nodes are connecting to the correct network.
