### PR TITLE
rm : erigon hostname

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,7 @@ GENESIS_CONTRACTS_BRANCH=master# Genesis contracts branch defining the version t
 MATIC_CLI_REPO="https://github.com/maticnetwork/matic-cli.git" # repo of matic-cli to run a specific version remotely using express-cli
 MATIC_CLI_BRANCH=master # matic-cli branch used on the remote machines to start the environment
 DEVNET_BOR_USERS=ubuntu,ubuntu,ubuntu # users' names of VMs for all the nodes (comma separated). Its length must be equal to "TF_VAR_BOR_VALIDATOR_COUNT + TF_VAR_BOR_SENTRY_COUNT + TF_VAR_BOR_ARCHIVE_COUNT"
-DEVNET_ERIGON_USERS=ubuntu # users' names of VMs for all the nodes (comma separated). Its length must be equal to "TF_VAR_ERIGON_VALIDATOR_COUNT + TF_VAR_ERIGON_SENTRY_COUNT + TF_VAR_ERIGON_ARCHIVE_COUNT"
+DEVNET_ERIGON_USERS= # users' names of VMs for all the nodes (comma separated). Its length must be equal to "TF_VAR_ERIGON_VALIDATOR_COUNT + TF_VAR_ERIGON_SENTRY_COUNT + TF_VAR_ERIGON_ARCHIVE_COUNT"
 BOR_DOCKER_BUILD_CONTEXT="https://github.com/maticnetwork/bor.git#develop" # todo change to develop once https://polygon.atlassian.net/browse/POS-979 is solved (docker build context for bor. Used in docker setup (TF_VAR_DOCKERIZED=yes))
 HEIMDALL_DOCKER_BUILD_CONTEXT="https://github.com/maticnetwork/heimdall.git#develop" # docker build context for heimdall. Used in docker setup (TF_VAR_DOCKERIZED=yes)
 VERBOSE=true # if set to true will print logs also from remote machines


### PR DESCRIPTION
In this PR, we remove `ubuntu` from erigon users as it creates inconsistency when `0` erigon nodes are selected to deploy in the devnet.