### PR TITLE
Use otelcol-contrib package for traces instead of docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 test
 .DS_Store
-devnet
+/devnet
 .env
 *.tfvars
 .terraform*

--- a/configs/devnet/install-otelcol-contrib.sh
+++ b/configs/devnet/install-otelcol-contrib.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+{ # Prevent execution if this script was only partially downloaded
+set -e
+
+oops() {
+    echo "$0:" "$@" >&2
+    exit 1
+}
+
+umask 0022
+
+tmpDir="$(mktemp -d -t otel-collector-contrib-XXXXXXXXXXX || \
+          oops "Can't create temporary directory for downloading files")"
+cleanup() {
+    rm -rf "$tmpDir"
+}
+trap cleanup EXIT INT QUIT TERM
+
+otel_version="0.85.0"
+
+baseUrl="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${otel_version}"
+binary="otelcol-contrib_${otel_version}_linux_amd64.deb"
+
+url="${baseUrl}/${binary}"
+package=$tmpDir/$binary
+
+if command -v curl > /dev/null 2>&1; then
+    fetch() { curl -L "$1" -o "$2"; }
+elif command -v wget > /dev/null 2>&1; then
+    fetch() { wget "$1" -O "$2"; }
+else
+    oops "you don't have wget or curl installed, which I need to download the binary package"
+fi
+
+echo "Downloading otelcol-contrib binary package from '$url' to '$tmpDir'..."
+fetch "$url" "$package" || oops "failed to download '$url'"
+
+echo "Removing existing installation..."
+sudo dpkg -r otelcol-contrib
+
+echo "Installing $package ..."
+sudo dpkg -i $package
+
+echo "open collector contrib has been installed successfully!"
+
+} # End of wrapping

--- a/configs/devnet/otel-config-dd.yaml
+++ b/configs/devnet/otel-config-dd.yaml
@@ -3,34 +3,15 @@ receivers:
     protocols:
       grpc:
         endpoint: 127.0.0.1:4317
-  hostmetrics:
-    collection_interval: 10s
-    scrapers:
-      paging:
-        metrics:
-          system.paging.utilization:
-            enabled: true
-      cpu:
-        metrics:
-          system.cpu.utilization:
-            enabled: true
-      disk: null
-      filesystem:
-        metrics:
-          system.filesystem.utilization:
-            enabled: true
-      load: null
-      memory: null
-      network: null
-      processes: null
+  # Collect own metrics
   prometheus:
     config:
       scrape_configs:
-        - job_name: otelcol
-          scrape_interval: 10s
-          static_configs:
-            - targets:
-                - 0.0.0.0:8888
+      - job_name: 'otel-collector'
+        scrape_interval: 10s
+        static_configs:
+        - targets: ['0.0.0.0:8888']
+
 processors:
   batch:
     timeout: 10s
@@ -38,21 +19,14 @@ exporters:
   datadog:
     api:
       key: ${DD_API_KEY}
+
 service:
   pipelines:
-    metrics:
-      receivers:
-        - hostmetrics
-        - otlp
-        - prometheus
-      processors:
-        - batch
-      exporters:
-        - datadog
     traces:
-      receivers:
-        - otlp
-      processors:
-        - batch
-      exporters:
-        - datadog
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]
+    metrics:
+      receivers: [otlp, prometheus]
+      processors: [batch]
+      exporters: [datadog]

--- a/src/express/commands/setup-datadog.js
+++ b/src/express/commands/setup-datadog.js
@@ -99,11 +99,13 @@ export async function setupDatadog() {
     await runScpCommand(src, dest, maxRetries)
 
     // Install otel collector using the script
-    command = "sudo bash ~/install-otelcol-contrib.sh"
+    command = 'sudo bash ~/install-otelcol-contrib.sh'
     await runSshCommand(`${user}@${host}`, command, maxRetries)
 
     // Set the datadog api key in the otel config
-    console.log('📍Setting up datadog api key in otel config and copying the config')
+    console.log(
+      '📍Setting up datadog api key in otel config and copying the config'
+    )
     const otelConfig = await yaml.load(
       fs.readFileSync('./otel-config-dd.yaml', 'utf8'),
       undefined
@@ -115,16 +117,17 @@ export async function setupDatadog() {
     dest = `${user}@${host}:~/otel-config-dd.yaml`
     await runScpCommand(src, dest, maxRetries)
 
-    command = "sudo mv ~/otel-config-dd.yaml /etc/otelcol-contrib/config.yaml"
+    command = 'sudo mv ~/otel-config-dd.yaml /etc/otelcol-contrib/config.yaml'
     await runSshCommand(`${user}@${host}`, command, maxRetries)
-    
+
     // Restart the otel service
     console.log('📍Restarting the otel service')
-    command = "sudo systemctl daemon-reload && sudo service otelcol-contrib restart"
+    command =
+      'sudo systemctl daemon-reload && sudo service otelcol-contrib restart'
     await runSshCommand(`${user}@${host}`, command, maxRetries)
 
     // Remove the installation script
-    command = "rm ~/install-otelcol-contrib.sh"
+    command = 'rm ~/install-otelcol-contrib.sh'
     await runSshCommand(`${user}@${host}`, command, maxRetries)
 
     // revert dd api key

--- a/src/express/commands/setup-datadog.js
+++ b/src/express/commands/setup-datadog.js
@@ -9,7 +9,6 @@ const {
   runSshCommand,
   maxRetries
 } = require('../common/remote-worker')
-const { installDocker } = require('./start.js')
 
 const yaml = require('js-yaml')
 const fs = require('fs')

--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -489,6 +489,9 @@ export async function start() {
     `cp ../../configs/devnet/openmetrics-conf.yaml ../../deployments/devnet-${devnetId}`
   )
   shell.exec(
+    `cp ../../configs/devnet/install-otelcol-contrib.sh ../../deployments/devnet-${devnetId}`
+  )
+  shell.exec(
     `cp ../../configs/devnet/otel-config-dd.yaml ../../deployments/devnet-${devnetId}`
   )
 


### PR DESCRIPTION
# Description

Currently, we used docker image of open collector to parse and send traces to datadog. On our internal nodes, using docker is not advisable (suggestion from devops) and hence we're planning to use the package with a service file. In order to have the same setup on devnets as well, this PR makes changes for the same. Moreover, the config file has been simplified to *only* have traces and nothing else. As we'll move to coralogix soon, we will have a common config which will handle all the metrics and traces so for now (while we have datadog), we can have a minimalistic config

NOTE: Do not merge - trying to clarify few things from devops. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai