### PR TITLE
Added support for config file and other v0.3.0 cahnges

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,7 @@ GENESIS_CONTRACTS_BRANCH=master# Genesis contracts branch defining the version t
 MATIC_CLI_REPO="https://github.com/maticnetwork/matic-cli.git" # repo of matic-cli to run a specific version remotely using express-cli
 MATIC_CLI_BRANCH=master # matic-cli branch used on the remote machines to start the environment
 DEVNET_BOR_USERS=ubuntu,ubuntu,ubuntu # users' names of VMs for all the nodes (comma separated). Its length must be equal to "TF_VAR_BOR_VALIDATOR_COUNT + TF_VAR_BOR_SENTRY_COUNT + TF_VAR_BOR_ARCHIVE_COUNT"
+DEVNET_BOR_FLAGS=config,config,config # Specifies how bor should be started ('config', or 'cli'), by providing cli flags, or by using toml config file (length of DEVNET_BOR_FLAGS should match the length of DEVNET_BOR_USERS)
 DEVNET_ERIGON_USERS= # users' names of VMs for all the nodes (comma separated). Its length must be equal to "TF_VAR_ERIGON_VALIDATOR_COUNT + TF_VAR_ERIGON_SENTRY_COUNT + TF_VAR_ERIGON_ARCHIVE_COUNT"
 BOR_DOCKER_BUILD_CONTEXT="https://github.com/maticnetwork/bor.git#develop" # todo change to develop once https://polygon.atlassian.net/browse/POS-979 is solved (docker build context for bor. Used in docker setup (TF_VAR_DOCKERIZED=yes))
 HEIMDALL_DOCKER_BUILD_CONTEXT="https://github.com/maticnetwork/heimdall.git#develop" # docker build context for heimdall. Used in docker setup (TF_VAR_DOCKERIZED=yes)

--- a/configs/devnet/remote-setup-config.yaml
+++ b/configs/devnet/remote-setup-config.yaml
@@ -35,5 +35,8 @@ devnetBorUsers:
 devnetHeimdallUsers:
   - ubuntu
   - ubuntu
+devnetBorFlags:
+  - config
+  - config
 borDockerBuildContext: https://github.com/maticnetwork/bor.git#develop
 heimdallDockerBuildContext: https://github.com/maticnetwork/heimdall.git#develop

--- a/src/express/commands/chaos.js
+++ b/src/express/commands/chaos.js
@@ -10,7 +10,7 @@ const {
 } = require('../common/remote-worker')
 
 async function removeAllPeers(ip, staticNodes) {
-  let command = 'mv ~/.bor/static-nodes.json ~/.bor/static-nodes.json_bkp'
+  let command = 'mv /var/lib/bor/static-nodes.json /var/lib/bor/static-nodes.json_bkp'
   try {
     await runSshCommandWithoutExit(ip, command, 1)
   } catch (error) {
@@ -19,10 +19,10 @@ async function removeAllPeers(ip, staticNodes) {
 
   const tasks = []
   for (let i = 0; i < staticNodes.length; i++) {
-    command = `/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "admin.removeTrustedPeer('${staticNodes[i]}')"`
+    command = `/home/ubuntu/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec "admin.removeTrustedPeer('${staticNodes[i]}')"`
     tasks.push(runSshCommand(ip, command, maxRetries))
 
-    command = `/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "admin.removePeer('${staticNodes[i]}')"`
+    command = `/home/ubuntu/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec "admin.removePeer('${staticNodes[i]}')"`
     tasks.push(runSshCommand(ip, command, maxRetries))
   }
   console.log('📍Removing all peers')
@@ -33,7 +33,7 @@ async function removeAllPeers(ip, staticNodes) {
 async function addAllPeers(ip, staticNodes) {
   const tasks = []
   for (let i = 0; i < staticNodes.length; i++) {
-    const command = `/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "admin.addPeer('${staticNodes[i]}')"`
+    const command = `/home/ubuntu/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec "admin.addPeer('${staticNodes[i]}')"`
     tasks.push(runSshCommand(ip, command, maxRetries))
   }
   console.log('📍Adding all peers')

--- a/src/express/commands/chaos.js
+++ b/src/express/commands/chaos.js
@@ -10,7 +10,7 @@ const {
 } = require('../common/remote-worker')
 
 async function removeAllPeers(ip, staticNodes) {
-  let command = 'mv /var/lib/bor/static-nodes.json /var/lib/bor/static-nodes.json_bkp'
+  let command = 'sudo mv /var/lib/bor/static-nodes.json /var/lib/bor/static-nodes.json_bkp'
   try {
     await runSshCommandWithoutExit(ip, command, 1)
   } catch (error) {

--- a/src/express/commands/cleanup.js
+++ b/src/express/commands/cleanup.js
@@ -148,7 +148,7 @@ async function cleanupServices(doc) {
 
     if (hostToIndexMap.get(ip) < returnTotalBorNodes(doc)) {
       console.log('📍Cleaning up bor on machine ' + ip + ' ...')
-      command = 'rm -rf ~/.bor/data'
+      command = 'rm -rf /var/lib/bor/data'
       await runSshCommand(ip, command, maxRetries)
     } else {
       console.log('📍Cleaning up erigon on machine ' + ip + ' ...')

--- a/src/express/commands/rewind.js
+++ b/src/express/commands/rewind.js
@@ -35,7 +35,7 @@ export async function rewind(num) {
   const ip = `${borUsers[0]}@${borHosts[0]}`
 
   const getBlockNumberCommand =
-    '~/go/bin/bor attach ~/.bor/data/bor.ipc --exec "eth.blockNumber"'
+    '~/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec "eth.blockNumber"'
 
   const intitalBlockNumber = await runSshCommandWithReturn(
     ip,
@@ -46,7 +46,7 @@ export async function rewind(num) {
     `📍 Rewinding chain by ${num} blocks, \n📍 current block number: ${intitalBlockNumber}`
   )
 
-  const rewindCommand = `~/go/bin/bor attach ~/.bor/data/bor.ipc --exec "debug.setHead(web3.toHex(${intitalBlockNumber} - ${num}))"`
+  const rewindCommand = `~/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec "debug.setHead(web3.toHex(${intitalBlockNumber} - ${num}))"`
   await runSshCommand(ip, rewindCommand, maxRetries)
 
   const restartCommand = 'sudo service bor restart'

--- a/src/express/commands/shadow.js
+++ b/src/express/commands/shadow.js
@@ -48,7 +48,7 @@ export async function shadow(targetBlock) {
     console.log('❌ All the machines are past the target block! Exiting ...')
     process.exit(1)
   }
-  const shadowGenesisLocation = '~/.bor/shadow-genesis.json'
+  const shadowGenesisLocation = '/var/lib/bor/shadow-genesis.json'
   const startScriptLocation = '~/node/bor-start.sh'
   const launchFolder =
     process.env.NETWORK === 'mainnet' ? 'mainnet-v1' : 'testnet-v4'

--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -332,8 +332,8 @@ async function eventuallyCleanupPreviousDevnet(ips, devnetType, devnetId) {
       "sudo systemctl stop erigon.service || echo 'erigon not running on current machine...'"
     await runSshCommand(ip, command, maxRetries)
 
-    console.log('📍Removing .bor folder (if present) on machine ' + ip + ' ...')
-    command = 'sudo rm -rf ~/.bor'
+    console.log('📍Removing /var/lib/bor folder (if present) on machine ' + ip + ' ...')
+    command = 'sudo rm -rf /var/lib/bor'
     await runSshCommand(ip, command, maxRetries)
 
     console.log(
@@ -413,11 +413,11 @@ async function runDockerSetupWithMaticCLI(ips, devnetId) {
   console.log('📍Executing bor ipc tests...')
   console.log('📍1. Fetching admin.peers...')
   command =
-    'cd ~/matic-cli/devnet && docker exec bor0 bash -c "bor attach /root/.bor/data/bor.ipc -exec \'admin.peers\'"'
+    'cd ~/matic-cli/devnet && docker exec bor0 bash -c "bor attach /var/lib/bor/data/bor.ipc -exec \'admin.peers\'"'
   await runSshCommand(ip, command, maxRetries)
   console.log('📍2. Fetching eth.blockNumber...')
   command =
-    'cd ~/matic-cli/devnet && docker exec bor0 bash -c "bor attach /root/.bor/data/bor.ipc -exec \'eth.blockNumber\'"'
+    'cd ~/matic-cli/devnet && docker exec bor0 bash -c "bor attach /var/lib/bor/data/bor.ipc -exec \'eth.blockNumber\'"'
   await runSshCommand(ip, command, maxRetries)
   console.log('📍bor ipc tests executed...')
 }

--- a/src/express/common/config-utils.js
+++ b/src/express/common/config-utils.js
@@ -275,7 +275,7 @@ function validateUsersAndHosts() {
   console.log(
     '📍Validating DEVNET_BOR_USERS, DEVNET_BOR_HOSTS, DEVNET_ERIGON_USERS and DEVNET_ERIGON_HOSTS...'
   )
-  let borUsers, borHosts, erigonUsers, erigonHosts
+  let borUsers, borHosts, erigonUsers, erigonHosts, borFlags
   if (process.env.DEVNET_BOR_USERS && process.env.DEVNET_BOR_HOSTS) {
     borUsers = process.env.DEVNET_BOR_USERS.split(',')
     borHosts = process.env.DEVNET_BOR_HOSTS.split(',')
@@ -284,12 +284,25 @@ function validateUsersAndHosts() {
     erigonUsers = process.env.DEVNET_ERIGON_USERS.split(',')
     erigonHosts = process.env.DEVNET_ERIGON_HOSTS.split(',')
   }
+  if (process.env.DEVNET_BOR_FLAGS) {
+    borFlags = process.env.DEVNET_BOR_FLAGS.split(',')
+  }
   const borValCount = Number(process.env.TF_VAR_BOR_VALIDATOR_COUNT)
   const borSenCount = Number(process.env.TF_VAR_BOR_SENTRY_COUNT)
   const borArchiveCount = Number(process.env.TF_VAR_BOR_ARCHIVE_COUNT)
   const erigonValCount = Number(process.env.TF_VAR_ERIGON_VALIDATOR_COUNT)
   const erigonSenCount = Number(process.env.TF_VAR_ERIGON_SENTRY_COUNT)
   const erigonArchiveCount = Number(process.env.TF_VAR_ERIGON_ARCHIVE_COUNT)
+
+  if (process.env.DEVNET_BOR_USERS &&
+    process.env.DEVNET_BOR_FLAGS &&
+    borFlags.length !== borUsers.length
+    ) {
+      console.log(
+        '❌ DEVNET_BOR_USERS lengths and DEVNET_BOR_FLAGS length are not equal, please check your configs!'
+      )
+      process.exit(1)
+  }
 
   if (
     process.env.TF_VAR_DOCKERIZED === 'yes' &&
@@ -700,9 +713,11 @@ export async function editMaticCliRemoteYAMLConfig() {
     setConfigList('devnetHeimdallHosts', process.env.DEVNET_ERIGON_HOSTS, doc)
     deleteConfig('devnetBorUsers', doc)
     deleteConfig('devnetBorHosts', doc)
+    deleteConfig('devnetBorFlags', doc)
   } else if (!process.env.DEVNET_ERIGON_USERS) {
     setConfigList('devnetBorHosts', process.env.DEVNET_BOR_HOSTS, doc)
     setConfigList('devnetBorUsers', process.env.DEVNET_BOR_USERS, doc)
+    setConfigList('devnetBorFlags', process.env.DEVNET_BOR_FLAGS, doc)
     setConfigList('devnetHeimdallUsers', process.env.DEVNET_BOR_USERS, doc)
     setConfigList('devnetHeimdallHosts', process.env.DEVNET_BOR_HOSTS, doc)
     deleteConfig('devnetErigonUsers', doc)
@@ -710,6 +725,7 @@ export async function editMaticCliRemoteYAMLConfig() {
   } else {
     setConfigList('devnetBorHosts', process.env.DEVNET_BOR_HOSTS, doc)
     setConfigList('devnetBorUsers', process.env.DEVNET_BOR_USERS, doc)
+    setConfigList('devnetBorFlags', process.env.DEVNET_BOR_FLAGS, doc)
     setConfigList('devnetErigonHosts', process.env.DEVNET_ERIGON_HOSTS, doc)
     setConfigList('devnetErigonUsers', process.env.DEVNET_ERIGON_USERS, doc)
     setConfigList(

--- a/src/express/common/milestone-utils.js
+++ b/src/express/common/milestone-utils.js
@@ -179,7 +179,7 @@ export async function validateProposer(ip, proposer) {
 export async function removePeers(ip, peers) {
   const tasks = []
   for (let i = 0; i < peers.length; i++) {
-    const command = `~/go/bin/bor attach ~/.bor/data/bor.ipc --exec "admin.removePeer('${peers[i]}')"`
+    const command = `~/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec "admin.removePeer('${peers[i]}')"`
     tasks.push(runSshCommand(ip, command, maxRetries))
   }
 
@@ -198,7 +198,7 @@ export async function removePeers(ip, peers) {
 export async function addPeers(ip, peers) {
   const tasks = []
   for (let i = 0; i < peers.length; i++) {
-    const command = `~/go/bin/bor attach ~/.bor/data/bor.ipc --exec "admin.addPeer('${peers[i]}')"`
+    const command = `~/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec "admin.addPeer('${peers[i]}')"`
     tasks.push(runSshCommand(ip, command, maxRetries))
   }
 
@@ -216,7 +216,7 @@ export async function addPeers(ip, peers) {
 
 export async function getPeerLength(ip) {
   const command =
-    '/home/ubuntu/go/bin/bor attach ~/.bor/data/bor.ipc --exec "admin.peers.length"'
+    '/home/ubuntu/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec "admin.peers.length"'
   try {
     const length = await runSshCommandWithReturn(ip, command, maxRetries)
     return parseInt(length)
@@ -335,7 +335,7 @@ export async function validateClusters(ips, expectedPeers) {
 export async function getEnode(user, host) {
   const ip = `${user}@${host}`
   const command =
-    '~/go/bin/bor attach ~/.bor/data/bor.ipc --exec admin.nodeInfo.enode'
+    '~/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec admin.nodeInfo.enode'
   try {
     const fullEnode = await runSshCommandWithReturn(ip, command, maxRetries)
     let enode = String(fullEnode).split('@')[0].slice(1) // remove the local ip from the enode

--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -721,7 +721,7 @@ export class Devnet {
                 '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null',
                 '-i', '~/cert.pem',
                                 `${this.config.devnetBorUsers[i]}@${this.config.devnetBorHosts[i]}`,
-                                `bash ${this.config.targetDirectory}/bor-service-host.sh`
+                                `bash ${this.config.targetDirectory}/bor-service-host.sh ${this.config.devnetBorFlags[i]}`
               ], { stdio: getRemoteStdio() })
 
               // NOTE: Target location would vary depending on bor/heimdall version. Currently the setup works with bor and heimdall v0.3.x
@@ -736,7 +736,7 @@ export class Devnet {
               '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null',
               '-i', '~/cert.pem',
                             `${this.config.devnetBorUsers[i]}@${this.config.devnetBorHosts[i]}`,
-                            'bash ~/bor-service.sh'
+                            `bash ~/bor-service.sh ${this.config.devnetBorFlags[i]}`
             ], { stdio: getRemoteStdio() })
 
             await execa('ssh', [
@@ -1782,6 +1782,9 @@ export default async function (command) {
   const devnetErigonUsers = config.devnetErigonUsers || []
   const totalBorNodes = config.numOfBorValidators + config.numOfBorSentries + config.numOfBorArchiveNodes
 
+  // set devnet bor flags
+  let devnetBorFlags = config.devnetBorFlags || []
+
   // For docker, the devnetBorHosts conform to the subnet 172.20.1.0/24
   if (config.devnetType === 'docker') {
     devnetBorHosts = []
@@ -1797,7 +1800,8 @@ export default async function (command) {
     devnetHeimdallHosts,
     devnetHeimdallUsers,
     devnetErigonHosts,
-    devnetErigonUsers
+    devnetErigonUsers,
+    devnetBorFlags
   })
 
   // start setup

--- a/src/setup/devnet/templates/docker/docker-bor-config.toml.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-config.toml.njk
@@ -1,0 +1,193 @@
+chain = "/var/lib/bor/genesis.json"
+identity = "MyIdentity"
+verbosity = 3
+log-level = ""
+vmdebug = false
+datadir = "/var/lib/bor/data"
+ancient = ""
+"db.engine" = "leveldb"
+keystore = "/var/lib/bor/keystore"
+"rpc.batchlimit" = 100
+"rpc.returndatalimit" = 100000
+syncmode = "full"
+gcmode = "full"
+snapshot = true
+"bor.logs" = true
+ethstats = ""
+devfakeauthor = false
+
+["eth.requiredblocks"]
+
+[log]
+  vmodule = ""
+  json = false
+  backtrace = ""
+  debug = false
+
+[p2p]
+  maxpeers = 200
+  maxpendpeers = 50
+  bind = "0.0.0.0"
+  port = 30303
+  nodiscover = false
+  nat = "any"
+  netrestrict = ""
+  nodekey = ""
+  nodekeyhex = ""
+  txarrivalwait = "500ms"
+  [p2p.discovery]
+    v5disc = false
+    bootnodes = []
+    bootnodesv4 = []
+    bootnodesv5 = []
+    static-nodes = []
+    trusted-nodes = []
+    dns = []
+
+[heimdall]
+  url = "http://localhost:1317"
+  "bor.without" = false
+  grpc-address = ""
+  "bor.runheimdall" = false
+  "bor.runheimdallargs" = ""
+  "bor.useheimdallapp" = false
+
+[txpool]
+  locals = []
+  nolocals = true
+  journal = "transactions.rlp"
+  rejournal = "1h0m0s"
+  pricelimit = 1
+  pricebump = 10
+  accountslots = 128
+  globalslots = 20000
+  accountqueue = 16
+  globalqueue = 32768
+  lifetime = "0h16m0s"
+
+[miner]
+  mine = true
+  etherbase = ""
+  extradata = ""
+  gaslimit = 20000000
+  gasprice = "1000000000"
+  recommit = "2m5s"
+  commitinterrupt = true
+
+[jsonrpc]
+  ipcdisable = false
+  ipcpath = "/var/lib/bor/data/bor.ipc"
+  gascap = 50000000
+  evmtimeout = "5s"
+  txfeecap = 5.0
+  allow-unprotected-txs = false
+  enabledeprecatedpersonal = false
+  [jsonrpc.http]
+    enabled = true
+    port = 8545
+    prefix = ""
+    host = "0.0.0.0"
+    api = ["eth", "net", "web3", "txpool", "bor"]
+    vhosts = ["localhost"]
+    corsdomain = ["localhost"]
+    ep-size = 40
+    ep-requesttimeout = "0s"
+  [jsonrpc.ws]
+    enabled = true
+    port = 8546
+    prefix = ""
+    host = "0.0.0.0"
+    api = ["eth", "net", "web3", "txpool", "bor"]
+    origins = ["localhost"]
+    ep-size = 40
+    ep-requesttimeout = "0s"
+  [jsonrpc.graphql]
+    enabled = false
+    port = 0
+    prefix = ""
+    host = ""
+    vhosts = ["localhost"]
+    corsdomain = ["localhost"]
+    ep-size = 0
+    ep-requesttimeout = ""
+  [jsonrpc.auth]
+    jwtsecret = ""
+    addr = "localhost"
+    port = 8551
+    vhosts = ["localhost"]
+  [jsonrpc.timeouts]
+    read = "10s"
+    write = "30s"
+    idle = "2m0s"
+
+[gpo]
+  blocks = 20
+  percentile = 60
+  maxheaderhistory = 1024
+  maxblockhistory = 1024
+  maxprice = "500000000000"
+  ignoreprice = "2"
+
+[telemetry]
+  metrics = true
+  expensive = true
+  prometheus-addr = "127.0.0.1:7071"
+  opencollector-endpoint = "127.0.0.1:4317"
+  [telemetry.influx]
+    influxdb = false
+    endpoint = ""
+    database = ""
+    username = ""
+    password = ""
+    influxdbv2 = false
+    token = ""
+    bucket = ""
+    organization = ""
+    [telemetry.influx.tags]
+
+[cache]
+  cache = 1024
+  gc = 25
+  snapshot = 10
+  database = 50
+  trie = 15
+  journal = "triecache"
+  rejournal = "1h0m0s"
+  noprefetch = false
+  preimages = false
+  txlookuplimit = 2350000
+  triesinmemory = 128
+  timeout = "1h0m0s"
+  fdlimit = 0
+
+[leveldb]
+  compactiontablesize = 2
+  compactiontablesizemultiplier = 1.0
+  compactiontotalsize = 10
+  compactiontotalsizemultiplier = 10.0
+
+[accounts]
+  unlock = []
+  password = "/var/lib/bor/password.txt"
+  allow-insecure-unlock = true
+  lightkdf = false
+  disable-bor-wallet = true
+
+[grpc]
+  addr = ":3131"
+
+[developer]
+  dev = false
+  period = 0
+  gaslimit = 11500000
+
+[parallelevm]
+  enable = true
+  procs = 8
+
+[pprof]
+  pprof = false
+  port = 6060
+  addr = "127.0.0.1"
+  memprofilerate = 524288
+  blockprofilerate = 0

--- a/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
@@ -4,8 +4,8 @@ set -x
 
 for i in {0..{{ obj.totalNodes - 1 }}}
 do
-  NODE_DIR=/root/.bor
-  DATA_DIR=/root/.bor/data
+  NODE_DIR=/var/lib/bor
+  DATA_DIR=/var/lib/bor/data
   docker compose run --rm --entrypoint bash bor$i -c "
 mkdir -p $DATA_DIR/bor;
 cp $NODE_DIR/nodekey $DATA_DIR/bor/;

--- a/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
@@ -7,9 +7,9 @@ do
   NODE_DIR=$HOME/node
   DATA_DIR=/var/lib/bor/data
   docker compose run --rm --entrypoint bash bor$i -c "
-mkdir -p $DATA_DIR/bor;
-cp $NODE_DIR/bor/nodekey $DATA_DIR/bor/;
-cp $NODE_DIR/bor/static-nodes.json $DATA_DIR/bor/;
+sudo mkdir -p $DATA_DIR/bor;
+sudo cp $NODE_DIR/bor/nodekey $DATA_DIR/bor/;
+sudo cp $NODE_DIR/bor/static-nodes.json $DATA_DIR/bor/;
 "
 done
 

--- a/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
@@ -4,12 +4,12 @@ set -x
 
 for i in {0..{{ obj.totalNodes - 1 }}}
 do
-  NODE_DIR=/var/lib/bor
+  NODE_DIR=$HOME/node
   DATA_DIR=/var/lib/bor/data
   docker compose run --rm --entrypoint bash bor$i -c "
 mkdir -p $DATA_DIR/bor;
-cp $NODE_DIR/nodekey $DATA_DIR/bor/;
-cp $NODE_DIR/static-nodes.json $DATA_DIR/bor/;
+cp $NODE_DIR/bor/nodekey $DATA_DIR/bor/;
+cp $NODE_DIR/bor/static-nodes.json $DATA_DIR/bor/;
 "
 done
 

--- a/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-setup.sh.njk
@@ -6,8 +6,10 @@ for i in {0..{{ obj.totalNodes - 1 }}}
 do
   NODE_DIR=$HOME/node
   DATA_DIR=/var/lib/bor/data
+  BOR_DIR=/var/lib/bor
   docker compose run --rm --entrypoint bash bor$i -c "
 sudo mkdir -p $DATA_DIR/bor;
+sudo cp $NODE_DIR/bor-config.toml $BOR_DIR/config.toml
 sudo cp $NODE_DIR/bor/nodekey $DATA_DIR/bor/;
 sudo cp $NODE_DIR/bor/static-nodes.json $DATA_DIR/bor/;
 "

--- a/src/setup/devnet/templates/docker/docker-bor-start-config.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-start-config.sh.njk
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+set -x
+
+ADDRESSES=({% for s in obj.signerDumpData %}
+  "{{ s.address }}"{% endfor %}
+)
+
+INDEX=$1;
+ADDRESS=${ADDRESSES[$INDEX]};
+
+docker compose run --service-ports -d --name bor$INDEX --entrypoint bash bor$INDEX -c "
+touch /root/logs/bor.log
+bor server \
+  --config /var/lib/bor/config.toml \
+  --bor.heimdall http://heimdall$INDEX:1317 \
+  --unlock $ADDRESS \
+  --miner.etherbase $ADDRESS > /root/logs/bor.log 2>&1 &
+tail -f /root/logs/bor.log
+"

--- a/src/setup/devnet/templates/docker/docker-bor-start.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-start.sh.njk
@@ -2,9 +2,6 @@
 
 set -x
 
-NODE_DIR=/var/lib/bor
-DATA_DIR=/var/lib/bor/data
-
 ADDRESSES=({% for s in obj.signerDumpData %}
   "{{ s.address }}"{% endfor %}
 )
@@ -12,15 +9,12 @@ ADDRESSES=({% for s in obj.signerDumpData %}
 INDEX=$1;
 ADDRESS=${ADDRESSES[$INDEX]};
 
-NODE_DIR=/var/lib/bor
-DATA_DIR=/var/lib/bor/data
-
 docker compose run --service-ports -d --name bor$INDEX --entrypoint bash bor$INDEX -c "
 touch /root/logs/bor.log
 bor server \
-  --chain=$NODE_DIR/genesis.json \
+  --chain=/var/lib/bor/genesis.json \
   --identity matic-cli \
-  --datadir $DATA_DIR \
+  --datadir /var/lib/bor/data \
   --port 30303 \
   --bor.heimdall http://heimdall$INDEX:1317 \
   --http --http.addr '0.0.0.0' \
@@ -29,7 +23,7 @@ bor server \
   --http.corsdomain '*' \
   --ws.origins '*' \
   --http.port 8545 \
-  --ipcpath $DATA_DIR/bor.ipc \
+  --ipcpath /var/lib/bor/data/bor.ipc \
   --http.api 'personal,eth,net,web3,txpool,miner,admin,bor,debug' \
   --bor.logs=true \
   --syncmode 'full' \
@@ -41,8 +35,8 @@ bor server \
   --unlock $ADDRESS \
   --miner.etherbase $ADDRESS \
   --disable-bor-wallet=false \
-  --keystore $NODE_DIR/keystore \
-  --password $NODE_DIR/password.txt \
+  --keystore /var/lib/bor/keystore \
+  --password /var/lib/bor/password.txt \
   --allow-insecure-unlock \
   --mine > /root/logs/bor.log 2>&1 &
 tail -f /root/logs/bor.log

--- a/src/setup/devnet/templates/docker/docker-bor-start.sh.njk
+++ b/src/setup/devnet/templates/docker/docker-bor-start.sh.njk
@@ -2,8 +2,8 @@
 
 set -x
 
-NODE_DIR=/root/.bor
-DATA_DIR=/root/.bor/data
+NODE_DIR=/var/lib/bor
+DATA_DIR=/var/lib/bor/data
 
 ADDRESSES=({% for s in obj.signerDumpData %}
   "{{ s.address }}"{% endfor %}
@@ -12,8 +12,8 @@ ADDRESSES=({% for s in obj.signerDumpData %}
 INDEX=$1;
 ADDRESS=${ADDRESSES[$INDEX]};
 
-NODE_DIR=/root/.bor
-DATA_DIR=/root/.bor/data
+NODE_DIR=/var/lib/bor
+DATA_DIR=/var/lib/bor/data
 
 docker compose run --service-ports -d --name bor$INDEX --entrypoint bash bor$INDEX -c "
 touch /root/logs/bor.log

--- a/src/setup/devnet/templates/docker/docker-compose.yml.njk
+++ b/src/setup/devnet/templates/docker/docker-compose.yml.njk
@@ -75,7 +75,7 @@ services:
     environment:
       - HEIMDALL_URL=http://heimdall{{ node }}:1317
     volumes:
-      - ./devnet/node{{ node }}/bor:/root/.bor
+      - ./devnet/node{{ node }}/bor:/var/lib/bor
       - ./logs/node{{ node }}/bor:/root/logs
     {% if node == 0 %}
     ports:

--- a/src/setup/devnet/templates/remote/bor-service-host.sh
+++ b/src/setup/devnet/templates/remote/bor-service-host.sh
@@ -11,6 +11,9 @@ PATH=$NODE:$BIN_DIR:$GO:$PATH
 
 VALIDATOR_ADDRESS="`cat $BOR_HOME/address.txt`"
 
+# PSP - add this
+FLAG=config
+
 cat > metadata <<EOF
 VALIDATOR_ADDRESS=
 EOF
@@ -27,6 +30,29 @@ cat > ganache.service <<EOF
     KillSignal=SIGINT
 EOF
 
+if [ "$FLAG" = "config" ]
+then
+cat > bor.service <<EOF
+[Unit]
+  Description=bor
+  StartLimitIntervalSec=500
+  StartLimitBurst=5
+[Service]
+  Restart=on-failure
+  RestartSec=5s
+  WorkingDirectory=$NODE_DIR
+  Environment=PATH=$PATH
+  EnvironmentFile=$HOME/metadata
+  #ExecStartPre=/bin/bash $NODE_DIR/bor-setup.sh
+  ExecStart=/bin/bash $NODE_DIR/bor-start-config.sh
+  Type=simple
+  User=$USER
+  KillSignal=SIGINT
+  TimeoutStopSec=120
+[Install]
+  WantedBy=multi-user.target
+EOF
+else
 cat > bor.service <<EOF
 [Unit]
   Description=bor
@@ -47,6 +73,7 @@ cat > bor.service <<EOF
 [Install]
   WantedBy=multi-user.target
 EOF
+fi
 
 cat > heimdalld.service <<EOF
 [Unit]

--- a/src/setup/devnet/templates/remote/bor-service-host.sh
+++ b/src/setup/devnet/templates/remote/bor-service-host.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 NODE_DIR=$HOME/node
-BOR_HOME=$HOME/.bor
+BOR_HOME=/var/lib/bor
 BIN_DIR=$(go env GOPATH)/bin
 USER=$(whoami)
 source $HOME/.nvm/nvm.sh

--- a/src/setup/devnet/templates/remote/bor-service-host.sh
+++ b/src/setup/devnet/templates/remote/bor-service-host.sh
@@ -11,8 +11,7 @@ PATH=$NODE:$BIN_DIR:$GO:$PATH
 
 VALIDATOR_ADDRESS="`cat $NODE_DIR/bor/address.txt`"
 
-# PSP - add this
-FLAG=config
+FLAG=$1
 
 cat > metadata <<EOF
 VALIDATOR_ADDRESS=

--- a/src/setup/devnet/templates/remote/bor-service-host.sh
+++ b/src/setup/devnet/templates/remote/bor-service-host.sh
@@ -9,7 +9,7 @@ NODE=$(nvm which node)
 GO=$(go env GOROOT)/bin
 PATH=$NODE:$BIN_DIR:$GO:$PATH
 
-VALIDATOR_ADDRESS="`cat $BOR_HOME/address.txt`"
+VALIDATOR_ADDRESS="`cat $NODE_DIR/bor/address.txt`"
 
 # PSP - add this
 FLAG=config

--- a/src/setup/devnet/templates/remote/bor-service.sh
+++ b/src/setup/devnet/templates/remote/bor-service.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 NODE_DIR=$HOME/node
-BOR_HOME=$HOME/.bor
+BOR_HOME=/var/lib/bor
 BIN_DIR=$(go env GOPATH)/bin
 USER=$(whoami)
 source $HOME/.nvm/nvm.sh

--- a/src/setup/devnet/templates/remote/bor-service.sh
+++ b/src/setup/devnet/templates/remote/bor-service.sh
@@ -11,8 +11,7 @@ PATH=$NODE:$BIN_DIR:$GO:$PATH
 
 VALIDATOR_ADDRESS="`cat $NODE_DIR/bor/address.txt`"
 
-# PSP - add this
-FLAG=config
+FLAG=$1
 
 cat > metadata <<EOF
 VALIDATOR_ADDRESS=

--- a/src/setup/devnet/templates/remote/bor-service.sh
+++ b/src/setup/devnet/templates/remote/bor-service.sh
@@ -11,11 +11,37 @@ PATH=$NODE:$BIN_DIR:$GO:$PATH
 
 VALIDATOR_ADDRESS="`cat $BOR_HOME/address.txt`"
 
+# PSP - add this
+FLAG=config
+
 cat > metadata <<EOF
 VALIDATOR_ADDRESS=
 EOF
 
 
+if [ "$FLAG" = "config" ]
+then
+cat > bor.service <<EOF
+[Unit]
+  Description=bor
+  StartLimitIntervalSec=500
+  StartLimitBurst=5
+[Service]
+  Restart=on-failure
+  RestartSec=5s
+  WorkingDirectory=$NODE_DIR
+  Environment=PATH=$PATH
+  EnvironmentFile=$HOME/metadata
+  #ExecStartPre=/bin/bash $NODE_DIR/bor-setup.sh
+  ExecStart=/bin/bash $NODE_DIR/bor-start-config.sh
+  Type=simple
+  User=$USER
+  KillSignal=SIGINT
+  TimeoutStopSec=120
+[Install]
+  WantedBy=multi-user.target
+EOF
+else
 cat > bor.service <<EOF
 [Unit]
   Description=bor
@@ -36,6 +62,7 @@ cat > bor.service <<EOF
 [Install]
   WantedBy=multi-user.target
 EOF
+fi
 
 cat > heimdalld.service <<EOF
 [Unit]

--- a/src/setup/devnet/templates/remote/bor-service.sh
+++ b/src/setup/devnet/templates/remote/bor-service.sh
@@ -9,7 +9,7 @@ NODE=$(nvm which node)
 GO=$(go env GOROOT)/bin
 PATH=$NODE:$BIN_DIR:$GO:$PATH
 
-VALIDATOR_ADDRESS="`cat $BOR_HOME/address.txt`"
+VALIDATOR_ADDRESS="`cat $NODE_DIR/bor/address.txt`"
 
 # PSP - add this
 FLAG=config

--- a/src/setup/devnet/templates/remote/bor/bor-clean.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-clean.sh.njk
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
 NODE_DIR=$HOME/node
-BOR_HOME=$HOME/.bor
+BOR_HOME=/var/lib/bor
 
 rm -rf $BOR_HOME/data

--- a/src/setup/devnet/templates/remote/bor/bor-config.toml.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-config.toml.njk
@@ -1,0 +1,193 @@
+chain = "/var/lib/bor/genesis.json"
+identity = "MyIdentity"
+verbosity = 3
+log-level = ""
+vmdebug = false
+datadir = "/var/lib/bor/data"
+ancient = ""
+"db.engine" = "leveldb"
+keystore = "/var/lib/bor/keystore"
+"rpc.batchlimit" = 100
+"rpc.returndatalimit" = 100000
+syncmode = "full"
+gcmode = "full"
+snapshot = true
+"bor.logs" = true
+ethstats = ""
+devfakeauthor = false
+
+["eth.requiredblocks"]
+
+[log]
+  vmodule = ""
+  json = false
+  backtrace = ""
+  debug = false
+
+[p2p]
+  maxpeers = 200
+  maxpendpeers = 50
+  bind = "0.0.0.0"
+  port = 30303
+  nodiscover = false
+  nat = "any"
+  netrestrict = ""
+  nodekey = ""
+  nodekeyhex = ""
+  txarrivalwait = "500ms"
+  [p2p.discovery]
+    v5disc = false
+    bootnodes = []
+    bootnodesv4 = []
+    bootnodesv5 = []
+    static-nodes = []
+    trusted-nodes = []
+    dns = []
+
+[heimdall]
+  url = "http://localhost:1317"
+  "bor.without" = false
+  grpc-address = ""
+  "bor.runheimdall" = false
+  "bor.runheimdallargs" = ""
+  "bor.useheimdallapp" = false
+
+[txpool]
+  locals = []
+  nolocals = true
+  journal = "transactions.rlp"
+  rejournal = "1h0m0s"
+  pricelimit = 1
+  pricebump = 10
+  accountslots = 128
+  globalslots = 20000
+  accountqueue = 16
+  globalqueue = 32768
+  lifetime = "0h16m0s"
+
+[miner]
+  mine = true
+  etherbase = ""
+  extradata = ""
+  gaslimit = 20000000
+  gasprice = "1000000000"
+  recommit = "2m5s"
+  commitinterrupt = true
+
+[jsonrpc]
+  ipcdisable = false
+  ipcpath = "/var/lib/bor/data/bor.ipc"
+  gascap = 50000000
+  evmtimeout = "5s"
+  txfeecap = 5.0
+  allow-unprotected-txs = false
+  enabledeprecatedpersonal = false
+  [jsonrpc.http]
+    enabled = true
+    port = 8545
+    prefix = ""
+    host = "0.0.0.0"
+    api = ["eth", "net", "web3", "txpool", "bor"]
+    vhosts = ["localhost"]
+    corsdomain = ["localhost"]
+    ep-size = 40
+    ep-requesttimeout = "0s"
+  [jsonrpc.ws]
+    enabled = true
+    port = 8546
+    prefix = ""
+    host = "0.0.0.0"
+    api = ["eth", "net", "web3", "txpool", "bor"]
+    origins = ["localhost"]
+    ep-size = 40
+    ep-requesttimeout = "0s"
+  [jsonrpc.graphql]
+    enabled = false
+    port = 0
+    prefix = ""
+    host = ""
+    vhosts = ["localhost"]
+    corsdomain = ["localhost"]
+    ep-size = 0
+    ep-requesttimeout = ""
+  [jsonrpc.auth]
+    jwtsecret = ""
+    addr = "localhost"
+    port = 8551
+    vhosts = ["localhost"]
+  [jsonrpc.timeouts]
+    read = "10s"
+    write = "30s"
+    idle = "2m0s"
+
+[gpo]
+  blocks = 20
+  percentile = 60
+  maxheaderhistory = 1024
+  maxblockhistory = 1024
+  maxprice = "500000000000"
+  ignoreprice = "2"
+
+[telemetry]
+  metrics = true
+  expensive = true
+  prometheus-addr = "127.0.0.1:7071"
+  opencollector-endpoint = "127.0.0.1:4317"
+  [telemetry.influx]
+    influxdb = false
+    endpoint = ""
+    database = ""
+    username = ""
+    password = ""
+    influxdbv2 = false
+    token = ""
+    bucket = ""
+    organization = ""
+    [telemetry.influx.tags]
+
+[cache]
+  cache = 1024
+  gc = 25
+  snapshot = 10
+  database = 50
+  trie = 15
+  journal = "triecache"
+  rejournal = "1h0m0s"
+  noprefetch = false
+  preimages = false
+  txlookuplimit = 2350000
+  triesinmemory = 128
+  timeout = "1h0m0s"
+  fdlimit = 0
+
+[leveldb]
+  compactiontablesize = 2
+  compactiontablesizemultiplier = 1.0
+  compactiontotalsize = 10
+  compactiontotalsizemultiplier = 10.0
+
+[accounts]
+  unlock = []
+  password = "/var/lib/bor/password.txt"
+  allow-insecure-unlock = true
+  lightkdf = false
+  disable-bor-wallet = true
+
+[grpc]
+  addr = ":3131"
+
+[developer]
+  dev = false
+  period = 0
+  gaslimit = 11500000
+
+[parallelevm]
+  enable = true
+  procs = 8
+
+[pprof]
+  pprof = false
+  port = 6060
+  addr = "127.0.0.1"
+  memprofilerate = 524288
+  blockprofilerate = 0

--- a/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
@@ -4,6 +4,8 @@ NODE_DIR=$HOME/node
 BOR_HOME=/var/lib/bor
 LOG_HOME=$HOME/logs
 
+USER=$(whoami)
+
 # create heimdall file
 sudo mkdir -p $BOR_HOME $LOG_HOME
 
@@ -19,3 +21,5 @@ sudo cp $NODE_DIR/bor-config.toml $BOR_HOME/config.toml
 sudo cp $NODE_DIR/bor/nodekey $BOR_DATA_DIR/bor/
 sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/
 sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/bor/
+
+sudo chown -R $USER $BOR_HOME

--- a/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
@@ -15,11 +15,13 @@ sudo cp -rf $NODE_DIR/bor/* $BOR_HOME/
 # setup bor
 BOR_DATA_DIR=$BOR_HOME/data
 
+# copy static nodes from json to toml
+STATICNODES=$(cat node/bor/static-nodes.json)
+sed -i "s%.*static-nodes =.*%static-nodes = $(echo $STATICNODES)%g" $NODE_DIR/bor-config.toml
+
 # copy bor files
 sudo mkdir -p $BOR_DATA_DIR/bor;
 sudo cp $NODE_DIR/bor-config.toml $BOR_HOME/config.toml
 sudo cp $NODE_DIR/bor/nodekey $BOR_DATA_DIR/bor/
-sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/
-sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/bor/
 
 sudo chown -R $USER $BOR_HOME

--- a/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
@@ -23,5 +23,7 @@ sed -i "s%.*static-nodes =.*%static-nodes = $(echo $STATICNODES)%g" $NODE_DIR/bo
 sudo mkdir -p $BOR_DATA_DIR/bor;
 sudo cp $NODE_DIR/bor-config.toml $BOR_HOME/config.toml
 sudo cp $NODE_DIR/bor/nodekey $BOR_DATA_DIR/bor/
+sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/
+sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/bor/
 
 sudo chown -R $USER $BOR_HOME

--- a/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
@@ -5,7 +5,7 @@ BOR_HOME=/var/lib/bor
 LOG_HOME=$HOME/logs
 
 # create heimdall file
-mkdir -p $BOR_HOME $LOG_HOME
+sudo mkdir -p $BOR_HOME $LOG_HOME
 
 # copy node directories to home directories
 cp -rf $NODE_DIR/bor/* $BOR_HOME/
@@ -15,6 +15,6 @@ BOR_DATA_DIR=$BOR_HOME/data
 
 # copy bor files
 mkdir -p $BOR_DATA_DIR/bor;
-cp $BOR_HOME/nodekey $BOR_DATA_DIR/bor/
-cp $BOR_HOME/static-nodes.json $BOR_DATA_DIR/
-cp $BOR_HOME/static-nodes.json $BOR_DATA_DIR/bor/
+cp $NODE_DIR/bor/nodekey $BOR_DATA_DIR/bor/
+cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/
+cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/bor/

--- a/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
@@ -8,13 +8,13 @@ LOG_HOME=$HOME/logs
 sudo mkdir -p $BOR_HOME $LOG_HOME
 
 # copy node directories to home directories
-cp -rf $NODE_DIR/bor/* $BOR_HOME/
+sudo cp -rf $NODE_DIR/bor/* $BOR_HOME/
 
 # setup bor
 BOR_DATA_DIR=$BOR_HOME/data
 
 # copy bor files
-mkdir -p $BOR_DATA_DIR/bor;
-cp $NODE_DIR/bor/nodekey $BOR_DATA_DIR/bor/
-cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/
-cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/bor/
+sudo mkdir -p $BOR_DATA_DIR/bor;
+sudo cp $NODE_DIR/bor/nodekey $BOR_DATA_DIR/bor/
+sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/
+sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/bor/

--- a/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
@@ -15,6 +15,7 @@ BOR_DATA_DIR=$BOR_HOME/data
 
 # copy bor files
 sudo mkdir -p $BOR_DATA_DIR/bor;
+sudo cp $NODE_DIR/bor-config.toml $BOR_HOME/config.toml
 sudo cp $NODE_DIR/bor/nodekey $BOR_DATA_DIR/bor/
 sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/
 sudo cp $NODE_DIR/bor/static-nodes.json $BOR_DATA_DIR/bor/

--- a/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-setup.sh.njk
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 NODE_DIR=$HOME/node
-BOR_HOME=$HOME/.bor
+BOR_HOME=/var/lib/bor
 LOG_HOME=$HOME/logs
 
 # create heimdall file

--- a/src/setup/devnet/templates/remote/bor/bor-start-config.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-start-config.sh.njk
@@ -1,10 +1,12 @@
 #!/usr/bin/env sh
 
+NODE_DIR=$HOME/node
+
 # create heimdall file
-mkdir -p /var/lib/bor
+sudo mkdir -p /var/lib/bor
 
 # get address
-ADDRESS="`cat /var/lib/bor/address.txt`"
+ADDRESS="`cat $NODE_DIR/bor/address.txt`"
 
 # start bor
 bor server \

--- a/src/setup/devnet/templates/remote/bor/bor-start-config.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-start-config.sh.njk
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# create heimdall file
+mkdir -p /var/lib/bor
+
+# get address
+ADDRESS="`cat /var/lib/bor/address.txt`"
+
+# start bor
+bor server \
+  --config /var/lib/bor/config.toml \
+  --unlock $ADDRESS \
+  --miner.etherbase $ADDRESS \

--- a/src/setup/devnet/templates/remote/bor/bor-start.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-start.sh.njk
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-BOR_HOME=$HOME/.bor
+BOR_HOME=/var/lib/bor
 BOR_DATA_DIR=$BOR_HOME/data
 
 # create heimdall file

--- a/src/setup/devnet/templates/remote/bor/bor-start.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-start.sh.njk
@@ -1,10 +1,12 @@
 #!/usr/bin/env sh
 
+NODE_DIR=$HOME/node
+
 # create heimdall file
-mkdir -p /var/lib/bor
+sudo mkdir -p /var/lib/bor
 
 # get address
-ADDRESS="`cat /var/lib/bor/address.txt`"
+ADDRESS="`cat $NODE_DIR/bor/address.txt`"
 
 # start bor
 bor server \

--- a/src/setup/devnet/templates/remote/bor/bor-start.sh.njk
+++ b/src/setup/devnet/templates/remote/bor/bor-start.sh.njk
@@ -1,18 +1,15 @@
 #!/usr/bin/env sh
 
-BOR_HOME=/var/lib/bor
-BOR_DATA_DIR=$BOR_HOME/data
-
 # create heimdall file
-mkdir -p $BOR_HOME
+mkdir -p /var/lib/bor
 
 # get address
-ADDRESS="`cat $BOR_HOME/address.txt`"
+ADDRESS="`cat /var/lib/bor/address.txt`"
 
 # start bor
 bor server \
-  --chain=$BOR_HOME/genesis.json \
-  --datadir $BOR_DATA_DIR \
+  --chain=/var/lib/bor/genesis.json \
+  --datadir /var/lib/bor/data \
   --port 30303 \
   --bor.heimdall "http://localhost:1317" \
   --http --http.addr '0.0.0.0' \
@@ -20,7 +17,7 @@ bor server \
   --http.vhosts '*' \
   --http.corsdomain '*' \
   --http.port 8545 \
-  --ipcpath $BOR_DATA_DIR/bor.ipc \
+  --ipcpath /var/lib/bor/data/bor.ipc \
   --http.api 'eth,net,web3,txpool,bor,debug' \
   --bor.logs=true \
   --syncmode 'full' \
@@ -34,7 +31,7 @@ bor server \
   --metrics.opencollector-endpoint="127.0.0.1:4317" \
   --unlock $ADDRESS \
   --miner.etherbase $ADDRESS \
-  --keystore $BOR_HOME/keystore \
-  --password $BOR_HOME/password.txt \
+  --keystore /var/lib/bor/keystore \
+  --password /var/lib/bor/password.txt \
   --allow-insecure-unlock \
   --mine

--- a/tests/rpc-tests/rpc-test.js
+++ b/tests/rpc-tests/rpc-test.js
@@ -75,7 +75,7 @@ async function init() {
       const addFlagsCmd = `sed -i 's/--allow-insecure-unlock \\\\/&\\n  --disable-bor-wallet=false \\\\/' ${borStartScriptLocation}`
       const restartBorCmd = 'sudo service bor restart'
       const isSyncingCmd =
-        '~/go/bin/bor attach ~/.bor/data/bor.ipc --exec "eth.syncing"'
+        '~/go/bin/bor attach /var/lib/bor/data/bor.ipc --exec "eth.syncing"'
 
       console.log(
         '📍Updating start script on machine to unlock node account ... '
@@ -102,7 +102,7 @@ async function init() {
   }
   const web3 = await initWeb3(machine)
 
-  const src = `${ip}:~/.bor/address.txt`
+  const src = `${ip}:/var/lib/bor/address.txt`
   const dest = './address.txt'
   await runScpCommand(src, dest, maxRetries)
 


### PR DESCRIPTION
# Description

The following updates are made in this PR

- Added support for `config.toml` file in bor. (Configurable via .env file)
- Updated bor home path to `/var/lib/bor`.
- Deprecated passing static nodes via the `static-nodes.json` file, rather, passing it via the config file.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

#### It should never be the case...

- [ ] This PR requires changes to bor
  - In case link the PR here:
- [ ] This PR requires changes to heimdall
  - In case link the PR here:

## Testing

- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
