### PR TITLE
src/express: fix fund ganache accounts command for only erigon devnets

### DIFF
--- a/src/express/common/ganache-utils.js
+++ b/src/express/common/ganache-utils.js
@@ -10,7 +10,12 @@ const EthAmount = '10'
 // we implemented this workaround waiting for a migration to hardhat
 // (see internal issue https://polygon.atlassian.net/browse/POS-1869)
 export async function fundGanacheAccounts(doc) {
-  const machine0 = doc.devnetBorHosts[0]
+  let machine0
+  if (doc.devnetBorHosts) {
+    machine0 = doc.devnetBorHosts[0]
+  } else {
+    machine0 = doc.devnetErigonHosts[0]
+  }
 
   console.log('📍Transferring funds from ganache account[0] to others...')
   const src = `${doc.ethHostUser}@${machine0}:~/matic-cli/devnet/devnet/signer-dump.json`


### PR DESCRIPTION
# Description

Fund account in ganache command assumed devnets to have at least 1 bor node and hence failed for only erigon devnets. This PR fixes it. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

#### It should never be the case...

- [ ] This PR requires changes to bor
  - In case link the PR here:
- [ ] This PR requires changes to heimdall
  - In case link the PR here:

## Testing

- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
