### PR TITLE
`fundGanacheAccounts` for `docker-e2e` / bump `express` from `4.18.2` to `4.19.2`

### DIFF
--- a/.github/integration-tests/fund_ganache_accounts.sh
+++ b/.github/integration-tests/fund_ganache_accounts.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+host='localhost'
+
+echo "Transferring 1 ETH from ganache account[0] to all others..."
+
+signersFile="matic-cli/devnet/devnet/signer-dump.json"
+signersDump=$(jq . $signersFile)
+signersLength=$(jq '. | length' $signersFile)
+
+rootChainWeb3="http://${host}:9545"
+
+for ((i = 1; i < signersLength; i++)); do
+  to_address=$(echo "$signersDump" | jq -r ".[$i].address")
+  from_address=$(echo "$signersDump" | jq -r ".[0].address")
+  txReceipt=$(curl $rootChainWeb3 -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"'"$to_address"'","from":"'"$from_address"'","value":"0xDE0B6B3A7640000"}],"id":1}' -H "Content-Type: application/json")
+  txHash=$(echo "$txReceipt" | jq -r '.result')
+  echo "Funds transferred from $from_address to $to_address with txHash: $txHash"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,8 @@ jobs:
 
       - name: Run smoke tests
         run: |
+          echo "Funding ganache accounts..."
+          timeout 10m bash matic-cli/.github/integration-tests/bor_health.sh
           echo "Deposit 100 matic for each account to bor network"
           cd matic-cli/devnet/code/contracts
           npm run truffle exec scripts/deposit.js -- --network development $(jq -r .root.tokens.MaticToken contractAddresses.json) 100000000000000000000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Run smoke tests
         run: |
           echo "Funding ganache accounts..."
-          timeout 10m bash matic-cli/.github/integration-tests/bor_health.sh
+          timeout 10m bash matic-cli/.github/integration-tests/fund_ganache_accounts.sh
           echo "Deposit 100 matic for each account to bor network"
           cd matic-cli/devnet/code/contracts
           npm run truffle exec scripts/deposit.js -- --network development $(jq -r .root.tokens.MaticToken contractAddresses.json) 100000000000000000000

--- a/package-lock.json
+++ b/package-lock.json
@@ -4650,9 +4650,9 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6817,16 +6817,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -6857,29 +6857,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -6892,20 +6869,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/ext": {
       "version": "1.7.0",


### PR DESCRIPTION
This PR contains two features:

- Bumps [express](https://github.com/expressjs/express) from 4.18.2 to 4.19.2 as per dependabot PR https://github.com/maticnetwork/matic-cli/pull/229 (closed)
- Add `fundGanacheAccount` for `docker-e2e` tests. This reduces the `smoke-tests` duration for the `CI` as previously done for `bor` and `heimdall` too