### PR TITLE
chg: fix heimdall chain id

### DIFF
--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -1252,7 +1252,7 @@ export class Devnet {
             this.config.numOfBorValidators + this.config.numOfErigonValidators,
             '--n',
             this.config.numOfBorSentries + this.config.numOfBorArchiveNodes + this.config.numOfErigonSentries + this.config.numOfErigonArchiveNodes,
-            '--chain-id',
+            '--chain',
             this.config.heimdallChainId,
             '--node-host-prefix',
             'heimdall',

--- a/src/setup/heimdall/index.js
+++ b/src/setup/heimdall/index.js
@@ -270,7 +270,7 @@ export class Heimdall {
                 'init',
                 '--home',
                 this.heimdallDataDir,
-                '--chain-id',
+                '--chain',
                 this.heimdallChainId,
                 'heimdall-test'
               ],


### PR DESCRIPTION
# Description

This PR adapts `matic-cli` due to changes in https://github.com/maticnetwork/heimdall/pull/1169

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Breaking changes

With the [upgrade of cosmos-sdk](https://github.com/maticnetwork/cosmos-sdk/releases/tag/v0.38.5), `--chain-id` is now called `--chain` to fix its empty value in heimdall REST server, fixed by [this PR](https://github.com/maticnetwork/heimdall/pull/1169) based on [this work](https://github.com/maticnetwork/heimdall/pull/1146)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [x] This PR requires changes to heimdall
  - In case link the PR here: https://github.com/maticnetwork/heimdall/pull/1169

## Testing

- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai