### PR TITLE
allow private repos pulls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,7 @@ SPRINT_SIZE_BLOCK_NUMBER=0 # comma separated values defining the block heights o
 BLOCK_NUMBER=0 # comma separated values defining the block heights of bor where block time must change
 BLOCK_TIME=2 # comma separated values defining the block times for the relative BLOCK_NUMBERs
 BOR_REPO="https://github.com/maticnetwork/bor.git" # repo of bor project
+# BOR_REPO="https://<username>:<token>@github.com/<username>/<repo>.git" # example of private repo URL
 BOR_BRANCH=develop # bor branch defining the version to be used in the devnet
 ERIGON_REPO="https://github.com/ledgerwatch/erigon.git" # repo of Erigon project
 ERIGON_BRANCH=main # Erigon branch defining the version to be used in the devnet

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ The `express-cli` also comes with additional utility commands, listed below. Som
   - Transfers 10 eth to all the ganache accounts.
 
 Note: to allow `express-cli` to clone private repos, make sure the git configs in the `.env` file looks like the following (example for `BOR_REPO`)
+
 ```shell
 # BOR_REPO="https://<username>:<token>@github.com/<username>/<repo>.git" # example of private repo URL
 ```

--- a/README.md
+++ b/README.md
@@ -306,6 +306,11 @@ The `express-cli` also comes with additional utility commands, listed below. Som
 - `../../bin/express-cli.js --fund-ganache-accounts`
   - Transfers 10 eth to all the ganache accounts.
 
+Note: to allow `express-cli` to clone private repos, make sure the git configs in the `.env` file looks like the following (example for `BOR_REPO`)
+```shell
+# BOR_REPO="https://<username>:<token>@github.com/<username>/<repo>.git" # example of private repo URL
+```
+
 ## `Milestone tests`
 
 The `express-cli` can also be used to perform few simulation based tests for the upcoming milestone feature. Please refer to the steps and requirements mentioned over [here](./docs/milestones.md) for running the tests.

--- a/src/express/common/config-utils.js
+++ b/src/express/common/config-utils.js
@@ -206,27 +206,27 @@ function validateEnvVars(cloud) {
     BLOCK_NUMBER: validStr({ default: '0,64' }),
     BLOCK_TIME: validStr({ default: '3,2' }),
     DEVNET_BOR_FLAGS: validStr({ default: 'config,cli' }),
-    BOR_REPO: url({
+    BOR_REPO: validStr({
       default: 'https://github.com/maticnetwork/bor.git'
     }),
     BOR_BRANCH: validStr({ default: 'develop' }),
-    ERIGON_REPO: url({
+    ERIGON_REPO: validStr({
       default: 'https://github.com/ledgerwatch/erigon.git'
     }),
     ERIGON_BRANCH: validStr({ default: 'main' }),
-    HEIMDALL_REPO: url({
+    HEIMDALL_REPO: validStr({
       default: 'https://github.com/maticnetwork/heimdall.git'
     }),
     HEIMDALL_BRANCH: validStr({ default: 'develop' }),
-    CONTRACTS_REPO: url({
+    CONTRACTS_REPO: validStr({
       default: 'https://github.com/maticnetwork/contracts.git'
     }),
     CONTRACTS_BRANCH: validStr({ default: 'master' }),
-    GENESIS_CONTRACTS_REPO: url({
+    GENESIS_CONTRACTS_REPO: validStr({
       default: 'https://github.com/maticnetwork/genesis-contracts.git'
     }),
     GENESIS_CONTRACTS_BRANCH: validStr({ default: 'master' }),
-    MATIC_CLI_REPO: url({
+    MATIC_CLI_REPO: validStr({
       default: 'https://github.com/maticnetwork/matic-cli.git'
     }),
     MATIC_CLI_BRANCH: validStr({ default: 'master' }),


### PR DESCRIPTION
# Description

With these changes, `express-cli` can clone/pull private repos.
This is particularly useful when dealing with security tasks.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai