### PR TITLE
Use github.head_ref and github.ref_name as env in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,14 @@ jobs:
 
       - name: Create .env file
         working-directory: matic-cli
+        env:
+          GITHUB_HEAD_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           cp .env.example .env
           sed -i 's,YOUR_IDENTIFIER,matic-cli-ci,' .env
           sed -i 's,aws-key,matic-cli-ci-key,' .env
           sed -i 's,/absolute/path/to/your/,/home/runner/work/matic-cli/matic-cli/matic-cli/aws/,' .env
-          sed -i 's,MATIC_CLI_BRANCH=master,MATIC_CLI_BRANCH=${{ github.head_ref || github.ref_name }},' .env
+          sed -i 's,MATIC_CLI_BRANCH=master,MATIC_CLI_BRANCH=$GITHUB_HEAD_REF,' .env
 
       - name: Get GitHub action runner IP
         id: ip


### PR DESCRIPTION
# Description

This PR passes the `github.head_ref` and `github.ref_name` inputs as env variables in the CI. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai

