### PR TITLE
Restrict ports access and remove cert validation

### DIFF
--- a/src/express/common/config-utils.js
+++ b/src/express/common/config-utils.js
@@ -54,8 +54,7 @@ const validCertPathStr = makeValidator((x) => {
     x !== undefined &&
     x !== null &&
     x !== '' &&
-    !x.startsWith('~') &&
-    (x.endsWith('.pem') || x.endsWith('.cer'))
+    !x.startsWith('~')
   ) {
     console.log('Done Checking path..')
     return x

--- a/src/express/common/config-utils.js
+++ b/src/express/common/config-utils.js
@@ -50,12 +50,7 @@ const validZone = makeValidator((x) => {
 })
 
 const validCertPathStr = makeValidator((x) => {
-  if (
-    x !== undefined &&
-    x !== null &&
-    x !== '' &&
-    !x.startsWith('~')
-  ) {
+  if (x !== undefined && x !== null && x !== '' && !x.startsWith('~')) {
     console.log('Done Checking path..')
     return x
   } else throw new Error(x + 'is not valid, please check your configs!')

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -120,7 +120,7 @@ resource "aws_security_group" "internet_facing_load_balancer_sg" {
       description = "web traffic to internet"
       from_port   = egress.value
       to_port     = egress.value
-      protocol    = "-1"
+      protocol    = "tcp"
       cidr_blocks = var.SG_CIDR_BLOCKS_OUT
       self = true
     }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -120,7 +120,7 @@ resource "aws_security_group" "internet_facing_load_balancer_sg" {
       description = "web traffic to internet"
       from_port   = egress.value
       to_port     = egress.value
-      protocol    = "tcp"
+      protocol    = "-1"
       cidr_blocks = var.SG_CIDR_BLOCKS_OUT
       self = true
     }

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,4 +1,4 @@
-# Provider and Terraform Configuration 
+# Provider and Terraform Configuration
 
 terraform {
   required_providers {
@@ -183,7 +183,8 @@ resource "google_compute_firewall" "allow_internal_access" {
   direction = "INGRESS"
   priority  = 1000
   allow {
-    protocol = "all"
+    protocol = "tcp"
+    ports    = var.PORTS_IN
   }
   source_tags = [var.VM_NAME]
   target_tags = [var.VM_NAME]
@@ -195,7 +196,8 @@ resource "google_compute_firewall" "allow_devnet_vm_connection" {
   direction = "INGRESS"
   priority  = 1000
   allow {
-    protocol = "all"
+    protocol = "tcp"
+    ports    = var.PORTS_IN
   }
   source_ranges = concat(google_compute_address.bor_static_ip.*.address, google_compute_address.erigon_static_ip.*.address, google_compute_address.docker_static_ip.*.address)
   target_tags = [var.VM_NAME]


### PR DESCRIPTION
# Description

In this PR, we modify the `terraform` scripts to only allow a specific number of ports for the different VMs to interact with each other within the same VPC / devnet.
For all devnets, the alert on DD would still be triggered.

Also, the cert validation has been removed since it's not a requirement on GCP (and would not make sense to only keep it for AWS, since an error would be triggered anyway).

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewers or the whole pos-v1 team
- [x] I have added sufficient documentation in the code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai or amoy