### PR TITLE
Include bor logs by default on remote deployments

### DIFF
--- a/src/setup/bor/templates/bor-start.sh.njk
+++ b/src/setup/bor/templates/bor-start.sh.njk
@@ -41,4 +41,5 @@ $BUILD_DIR/bor --datadir $BOR_DATA_DIR \
   --maxpeers 200 \
   --metrics \
   --pprof --pprof.port 7071 --pprof.addr '0.0.0.0' \
+  --bor.logs true \
   --mine


### PR DESCRIPTION
# Description

Based on #279 , and thanks to @marcello33 . I'm including bor logs by default in remote deployments. They are important to filter StateSync events.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Checklist

- [x] I have added at least 2 reviewers or the whole pos-v1 team
- [ ] I have added sufficient documentation in the code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply