### PR TITLE
use random string generator for ci gcp resources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ TF_VAR_BOR_ARCHIVE_VOLUME_TYPE_GCP=pd-balanced # type of EBS volume for Bor arch
 TF_VAR_ERIGON_ARCHIVE_VOLUME_TYPE_GCP=pd-balanced # type of EBS volume for Erigon archive nodes (default is pd-balanced)
 
 # Terraform variables - Common for both AWS and GCP
-TF_VAR_VM_NAME=polygon-user # default "polygon-user". It can be any string, used to discriminate between instances
+TF_VAR_VM_NAME=polygon-user # It can be any string, used to discriminate between instances
 TF_VAR_DOCKERIZED=no # default "no", otherwise only one VM is created and the Polygon devnet will run in docker containers
 TF_VAR_BOR_DISK_SIZE_GB=20 # size of the disk in GB for Bor client (default is 20GB)
 TF_VAR_ERIGON_DISK_SIZE_GB=20 # size of the disk in GB for Erigon client (default is 20GB)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: matic-cli
+      - uses: boonya/gh-action-name-generator@v1
+        id: generator
+        with:
+          length: 2
+          style: lowerCase
 
       - name: Create .env file
         working-directory: matic-cli
@@ -65,7 +70,7 @@ jobs:
           GITHUB_HEAD_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           cp .env.example .env
-          sed -i 's,YOUR_IDENTIFIER,matic-cli-ci,' .env
+          sed -i 's,polygon-user,${{steps.generator.outputs.name}},' .env
           sed -i 's,gcp-key,matic-cli-ci-key,' .env
           sed -i 's,/absolute/path/to/your/,/home/runner/work/matic-cli/matic-cli/matic-cli/gcp/,' .env
           sed -i 's,YOUR_PROJECT_ID,prj-polygonlabs-pos-v1-dev,' .env


### PR DESCRIPTION
# Description

Use random string generator for ci gcp resources, to avoid conflicts.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet