### PR TITLE
fix: command injection shell command built from environment values

### DIFF
--- a/src/express/commands/start.js
+++ b/src/express/commands/start.js
@@ -456,14 +456,17 @@ export async function start() {
 
   await validateConfigs(cloud)
 
-  shell.exec(
-    `cp ../../configs/devnet/${devnetType}-setup-config.yaml ../../deployments/devnet-${devnetId}`
+  shell.cp(
+    '../../configs/devnet/${devnetType}-setup-config.yaml',
+    `../../deployments/devnet-${devnetId}`
   )
-  shell.exec(
-    `cp ../../configs/devnet/openmetrics-conf.yaml ../../deployments/devnet-${devnetId}`
+  shell.cp(
+    '../../configs/devnet/openmetrics-conf.yaml',
+    `../../deployments/devnet-${devnetId}`
   )
-  shell.exec(
-    `cp ../../configs/devnet/otel-config-dd.yaml ../../deployments/devnet-${devnetId}`
+  shell.cp(
+    '../../configs/devnet/otel-config-dd.yaml',
+    `../../deployments/devnet-${devnetId}`
   )
 
   if (devnetType === 'docker') {


### PR DESCRIPTION
# Description
Issue ticket #320

To fix the problem, we should avoid constructing shell commands dynamically with unsanitized input values. Instead, we can use `shell.cp` to copy files, which does not invoke a shell and thus avoids the risk of command injection. This approach maintains the existing functionality while ensuring that the input values are not interpreted by the shell.

[Command Injection](https://www.owasp.org/index.php/Command_Injection)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)


# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have added at least 2 reviewers or the whole pos-v1 team
- [ ] I have added sufficient documentation in the code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

#### It should never be the case...

- [ ] This PR requires changes to bor
  - In case link the PR here:
- [ ] This PR requires changes to heimdall
  - In case link the PR here:

## Testing

- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai or amoy

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it


