### PR TITLE
tests/rpc-tests: remove total difficulty from rpc tests

### DIFF
--- a/tests/rpc-tests/main.go
+++ b/tests/rpc-tests/main.go
@@ -54,7 +54,6 @@ type ResponseMap struct {
 	chainId                                *big.Int
 	mostRecentBlockNumber                  *big.Int
 	mostRecentBlockHash                    common.Hash
-	mostRecentBlockTotalDifficulty         *big.Int
 	mostRecentBlockParentHash              common.Hash
 	currentProposerAddress                 common.Address
 	account                                Account
@@ -486,7 +485,7 @@ func validateBlock(block map[string]interface{}) error {
 	// Validate specific required fields
 	requiredFields := []string{
 		"baseFeePerGas", "difficulty", "gasLimit", "gasUsed",
-		"hash", "number", "timestamp", "parentHash", "totalDifficulty", "miner",
+		"hash", "number", "timestamp", "parentHash", "miner",
 	}
 
 	for _, field := range requiredFields {
@@ -511,16 +510,6 @@ func validateBlock(block map[string]interface{}) error {
 		blockTime := value.Int64()
 		if blockTime < currentTime-3600 || blockTime > currentTime+3600 {
 			return fmt.Errorf("timestamp is too far from current time: %d", blockTime)
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	// Validate "totalDifficulty" (must be greater than zero)
-	if err := validateHexBigInt(block["totalDifficulty"], "totalDifficulty", func(value *big.Int) error {
-		if value.Cmp(big.NewInt(0)) <= 0 {
-			return errors.New("totalDifficulty must be greater than zero")
 		}
 		return nil
 	}); err != nil {
@@ -581,8 +570,7 @@ func validateHeader(header map[string]interface{}) error {
 		"baseFeePerGas", "difficulty", "extraData", "gasLimit",
 		"gasUsed", "hash", "logsBloom", "miner", "mixHash",
 		"nonce", "number", "parentHash", "receiptsRoot",
-		"sha3Uncles", "stateRoot", "timestamp", "totalDifficulty",
-		"transactionsRoot",
+		"sha3Uncles", "stateRoot", "timestamp", "transactionsRoot",
 	}
 
 	for _, field := range requiredFields {
@@ -1104,10 +1092,8 @@ var testCases = []TestCase{
 			}
 			blockHash, _ := (*block)["hash"].(string)
 			parentHash, _ := (*block)["parentHash"].(string)
-			totalDifficulty, _ := (*block)["totalDifficulty"].(string)
 			rm.mostRecentBlockHash = common.HexToHash(blockHash)
 			rm.mostRecentBlockParentHash = common.HexToHash(parentHash)
-			rm.mostRecentBlockTotalDifficulty, _ = hexStringToBigInt(totalDifficulty)
 			return nil
 		},
 	},
@@ -1125,11 +1111,6 @@ var testCases = []TestCase{
 			err = validateBlock(*block)
 			if err != nil {
 				return err
-			}
-			totalDifficultyHex, _ := (*block)["totalDifficulty"].(string)
-			totalDifficulty, _ := hexStringToBigInt(totalDifficultyHex)
-			if rm.mostRecentBlockTotalDifficulty.Cmp(totalDifficulty) <= 0 {
-				return fmt.Errorf("parent block must always have less total difficulty than child block")
 			}
 			return nil
 		},


### PR DESCRIPTION
# Description

With upstream merge v1.14.11 done in [this PR](https://github.com/maticnetwork/bor/pull/1452) in bor, the total difficulty field will be removed from the rpc responses. This PR updates the tests to handle the removal of that field. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have added at least 2 reviewers or the whole pos-v1 team
- [ ] I have added sufficient documentation in the code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

#### It should never be the case...

- [ ] This PR requires changes to bor
  - In case link the PR here:
- [ ] This PR requires changes to heimdall
  - In case link the PR here:

## Testing

- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai or amoy

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
