### PR TITLE
symlink for heimdallcli

### DIFF
--- a/src/setup/devnet/index.js
+++ b/src/setup/devnet/index.js
@@ -1045,6 +1045,21 @@ export class Devnet {
                 '-i',
                 '~/cert.pem',
                 `${this.config.devnetBorUsers[i]}@${this.config.devnetBorHosts[i]}`,
+                'sudo ln -sf ~/go/bin/heimdallcli /usr/bin/heimdallcli'
+              ],
+              { stdio: getRemoteStdio() }
+            )
+
+            await execa(
+              'ssh',
+              [
+                '-o',
+                'StrictHostKeyChecking=no',
+                '-o',
+                'UserKnownHostsFile=/dev/null',
+                '-i',
+                '~/cert.pem',
+                `${this.config.devnetBorUsers[i]}@${this.config.devnetBorHosts[i]}`,
                 'sudo systemctl start heimdalld.service'
               ],
               { stdio: getRemoteStdio() }
@@ -1210,6 +1225,21 @@ export class Devnet {
                 '~/cert.pem',
                 `${this.config.devnetErigonUsers[i]}@${this.config.devnetErigonHosts[i]}`,
                 'sudo ln -sf ~/go/bin/heimdalld /usr/bin/heimdalld'
+              ],
+              { stdio: getRemoteStdio() }
+            )
+
+            await execa(
+              'ssh',
+              [
+                '-o',
+                'StrictHostKeyChecking=no',
+                '-o',
+                'UserKnownHostsFile=/dev/null',
+                '-i',
+                '~/cert.pem',
+                `${this.config.devnetBorUsers[i]}@${this.config.devnetBorHosts[i]}`,
+                'sudo ln -sf ~/go/bin/heimdallcli /usr/bin/heimdallcli'
               ],
               { stdio: getRemoteStdio() }
             )


### PR DESCRIPTION
# Description

Add a symlink for `heimdallcli` in devnets.
This facilitates the migration tests for heimdall v2.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] New test case for remote devnet
