### PR TITLE
chore(tests): improve smoke tests

### DIFF
--- a/configs/devnet/docker-setup-config.yaml
+++ b/configs/devnet/docker-setup-config.yaml
@@ -1,9 +1,9 @@
 # Repositories
 borRepo: https://github.com/maticnetwork/bor.git
-borBranch: develop
+borBranch: v2.2.3-beta
 
 heimdallRepo: https://github.com/0xPolygon/heimdall-v2.git
-heimdallBranch: develop
+heimdallBranch: krishang/record-count
 
 contractsRepo: https://github.com/0xPolygon/pos-contracts.git
 contractsBranch: anvil-pos
@@ -21,20 +21,20 @@ ethURL: http://anvil:9545 # use localhost for local deployments
 ethHostUser: ubuntu
 
 # Misc
-mnemonic: "clock radar mass judge dismiss just intact mind resemble fringe diary casino"
+mnemonic: 'clock radar mass judge dismiss just intact mind resemble fringe diary casino'
 
 # Heimdall
 heimdallChainId: heimdall-15005
-heimdallDockerBuildContext: https://github.com/0xPolygon/heimdall-v2.git#develop
+heimdallDockerBuildContext: https://github.com/0xPolygon/heimdall-v2.git#krishang/record-count
 
 # Bor
 borChainId: 15005
-borDockerBuildContext: https://github.com/maticnetwork/bor.git#develop
+borDockerBuildContext: https://github.com/maticnetwork/bor.git#v2.2.3-beta
 
 blockTime: '2'
 blockNumber: '0'
 
-sprintSize: '64'
+sprintSize: '16'
 sprintSizeBlockNumber: '0'
 
 # Bor

--- a/src/setup/anvil/templates/anvil-deploy-dependencies.sh.njk
+++ b/src/setup/anvil/templates/anvil-deploy-dependencies.sh.njk
@@ -19,11 +19,12 @@ cd {{ obj.contracts.repositoryDir }}
 
 export PATH="$HOME/.foundry/bin:$PATH"
 
- forge create --rpc-url http://localhost:$SERVER_PORT --private-key $ANVIL_ACC contracts/common/lib/Common.sol:Common --broadcast
+sleep 5
 
+forge create --rpc-url http://localhost:$SERVER_PORT --private-key $ANVIL_ACC contracts/common/lib/Common.sol:Common --broadcast
 forge create --rpc-url http://localhost:$SERVER_PORT --private-key $ANVIL_ACC contracts/root/predicates/TransferWithSigUtils.sol:TransferWithSigUtils --broadcast
 
 {% for acc in obj.config.accounts %}
 cast send --rpc-url http://localhost:$SERVER_PORT --private-key $ANVIL_ACC {{ acc.address }} --value 10000ether
-sleep 10
+sleep 5
 {% endfor %}

--- a/src/setup/anvil/templates/anvil-deployment-bor.sh.njk
+++ b/src/setup/anvil/templates/anvil-deployment-bor.sh.njk
@@ -16,4 +16,6 @@ cd {{ obj.contracts.repositoryDir }}
 
 export PATH="$HOME/.foundry/bin:$PATH"
 
+sleep 5
+
 forge script scripts/deployment-scripts/childContractDeployment.s.sol:ChildContractDeploymentScript --legacy --rpc-url http://localhost:8545 --private-key $PRIVATE_KEY --broadcast

--- a/src/setup/anvil/templates/anvil-deployment-sync.sh.njk
+++ b/src/setup/anvil/templates/anvil-deployment-sync.sh.njk
@@ -18,4 +18,6 @@ cd {{ obj.contracts.repositoryDir }}
 
 export PATH="$HOME/.foundry/bin:$PATH"
 
+sleep 5
+
 forge script scripts/deployment-scripts/syncChildStateToRoot.s.sol:SyncChildStateToRootScript --legacy --rpc-url http://localhost:$SERVER_PORT --private-key $PRIVATE_KEY --broadcast

--- a/src/setup/anvil/templates/anvil-deployment.sh.njk
+++ b/src/setup/anvil/templates/anvil-deployment.sh.njk
@@ -21,6 +21,8 @@ echo "HEIMDALL_ID='$HEIMDALL_ID'" >>.env
 
 export PATH="$HOME/.foundry/bin:$PATH"
 
+sleep 5
+
 # bor contracts are deployed on child chain
 forge script scripts/deployment-scripts/deployContracts.s.sol:DeploymentScript --legacy --rpc-url http://localhost:$SERVER_PORT --private-key $PRIVATE_KEY --broadcast
 

--- a/src/setup/anvil/templates/anvil-stake.sh.njk
+++ b/src/setup/anvil/templates/anvil-stake.sh.njk
@@ -12,8 +12,10 @@ export SERVER_PORT={{ obj.serverPort }}
 # Navigate to the matic contracts directory
 cd {{ obj.contracts.repositoryDir }}
 
+sleep 5
+
 # Loop over accounts and run the stake script for each
 {% for acc in obj.config.accounts %}
-  forge script scripts/matic-cli-scripts/stake.s.sol:MaticStake --legacy --rpc-url http://localhost:$SERVER_PORT --private-key $PRIVATE_KEY --broadcast --sig "run(address,bytes,uint256,uint256)" {{ acc.address }} {{ acc.pub_key }} 10000000000000000000000 2000000000000000000000
-sleep 10
+forge script scripts/matic-cli-scripts/stake.s.sol:MaticStake --legacy --rpc-url http://localhost:$SERVER_PORT --private-key $PRIVATE_KEY --broadcast --sig "run(address,bytes,uint256,uint256)" {{ acc.address }} {{ acc.pub_key }} 10000000000000000000000 2000000000000000000000
+sleep 5
 {% endfor %}

--- a/src/setup/anvil/templates/anvil-start.sh.njk
+++ b/src/setup/anvil/templates/anvil-start.sh.njk
@@ -18,3 +18,5 @@ anvil \
   --verbosity \
   --mnemonic "$MNEMONIC" \
   --block-time 1
+
+sleep 5

--- a/util-scripts/docker/smoke_test.sh
+++ b/util-scripts/docker/smoke_test.sh
@@ -1,61 +1,114 @@
 #!/bin/bash
 set -e
 
-echo "Starting the smoke tests for the local docker devnet..."
+echo "Starting smoke tests for the local docker devnet..."
 
 cd ./devnet
-SCRIPT_ADDRESS=$(jq -r '.[0].address' signer-dump.json)
-SCRIPT_PRIVATE_KEY=$(jq -r '.[0].priv_key' signer-dump.json)
+ADDRESS=$(jq -r '.[0].address' signer-dump.json)
+PRIVATE_KEY=$(jq -r '.[0].priv_key' signer-dump.json)
 
 cd ../code/pos-contracts
-CONTRACT_ADDRESS=$(jq -r .root.tokens.MaticToken contractAddresses.json)
+MATIC_CONTRACT_ADDRESS=$(jq -r .root.tokens.MaticToken contractAddresses.json)
 
-echo "Executing a deposit..."
+echo "Checking MATIC token balance before executing deposits..."
 export PATH="$HOME/.foundry/bin:$PATH"
-forge script scripts/matic-cli-scripts/Deposit.s.sol:MaticDeposit --legacy --rpc-url http://localhost:9545 --private-key $SCRIPT_PRIVATE_KEY --broadcast --sig "run(address,address,uint256)" $SCRIPT_ADDRESS $CONTRACT_ADDRESS 100000000000000000000
-echo "Deposit executed successfully! StateSync will kick in soon..."
 
-balanceInit=$(docker exec bor0 bash -c "bor attach /var/lib/bor/data/bor.ipc -exec 'Math.round(web3.fromWei(eth.getBalance(eth.accounts[0])))'")
+# Check MATIC token balance of the account.
+REQUIRED_BALANCE="100000000000000000000" # 100 MATIC tokens.
+CURRENT_BALANCE=$(cast call $MATIC_CONTRACT_ADDRESS "balanceOf(address)" $ADDRESS --rpc-url http://localhost:9545 | cast --to-dec)
 
-echo "Initial balance of first account: $balanceInit"
+echo "Current MATIC balance: $CURRENT_BALANCE"
+echo "Required MATIC balance: $REQUIRED_BALANCE (100 MATIC)"
 
-stateSyncFound="false"
-checkpointFound="false"
+# Use bc for large number comparison since bash can't handle wei amounts
+if [ $(echo "$CURRENT_BALANCE < $REQUIRED_BALANCE" | bc) -eq 1 ]; then
+	echo "❌ Error: Insufficient MATIC balance!"
+	echo "Current: $CURRENT_BALANCE"
+	echo "Required: $REQUIRED_BALANCE"
+	echo "Please fund the account with more MATIC tokens before running the smoke tests."
+	exit 1
+fi
+
+echo "✅ Balance check passed! Account has sufficient MATIC tokens."
+
+# Check the initial state sync event count in Heimdall before deposits.
+echo "Checking initial state sync event count in Heimdall..."
+INITIAL_EVENT_COUNT=$(curl -s localhost:1317/clerk/event-records/count | jq -r '.count' || echo "0")
+echo "Initial state sync event count: $INITIAL_EVENT_COUNT"
+
+# Check the initial BOR balance before deposits.
+INITIAL_BOR_BALANCE=$(docker exec bor0 bash -c "bor attach /var/lib/bor/data/bor.ipc --exec \"Math.round(web3.fromWei(eth.getBalance(eth.accounts[0]), 'ether'))\"")
+echo "Initial balance in BOR: $INITIAL_BOR_BALANCE"
+
+echo "Executing 100 deposits..."
+
+for i in {1..100}; do
+	echo "Executing deposit $i/100..."
+	forge script scripts/matic-cli-scripts/Deposit.s.sol:MaticDeposit --sig "run(address,address,uint256)" $ADDRESS $MATIC_CONTRACT_ADDRESS 1000000000000000000 --rpc-url http://localhost:9545 --private-key $PRIVATE_KEY --legacy --broadcast &>/dev/null
+	echo "✅ Deposit $i/100 executed successfully!"
+	sleep 0.5
+done
+
+echo "✅ All 100 deposits executed successfully! Waiting for Heimdall to process events..."
+
+# Wait for Heimdall to process all 100 events.
+EXPECTED_EVENT_COUNT=$((INITIAL_EVENT_COUNT + 100))
+echo "Waiting for Heimdall's clerk event count to reach: $EXPECTED_EVENT_COUNT"
+
 SECONDS=0
 start_time=$SECONDS
 
 while true; do
+	CURRENT_EVENT_COUNT=$(curl -s localhost:1317/clerk/event-records/count | jq -r '.count' || echo "0")
 
-    balance=$(docker exec bor0 bash -c "bor attach /var/lib/bor/data/bor.ipc -exec 'Math.round(web3.fromWei(eth.getBalance(eth.accounts[0])))'")
+	if [ "$CURRENT_EVENT_COUNT" -eq "$EXPECTED_EVENT_COUNT" ]; then
+		event_processing_time=$((SECONDS - start_time))
+		echo "✅ All 100 events processed by Heimdall!"
+		echo "Initial event count: $INITIAL_EVENT_COUNT"
+		echo "Final event count: $CURRENT_EVENT_COUNT"
+		echo "Events processed: $((CURRENT_EVENT_COUNT - INITIAL_EVENT_COUNT))"
+		echo "Time taken: $(printf '%02dm:%02ds\n' $((event_processing_time % 3600 / 60)) $((event_processing_time % 60)))"
+		break
+	fi
 
-    if ! [[ "$balance" =~ ^[0-9]+$ ]]; then
-        echo "Something is wrong! Can't find the balance of first account in bor network."
-        exit 1
-    fi
-
-    if ((balance > balanceInit)); then
-        if [ "$stateSyncFound" != "true" ]; then
-            stateSyncTime=$((SECONDS - start_time))
-            stateSyncFound="true"
-            echo "State sync went through. Time taken: $(printf '%02dm:%02ds\n' $((stateSyncTime % 3600 / 60)) $((stateSyncTime % 60)))"
-        fi
-    fi
-
-    checkpointID=$(curl -sL http://localhost:1317/checkpoints/latest | jq .checkpoint.id)
-
-    if [ "$checkpointID" != "null" ]; then
-        if [ "$checkpointFound" != "true" ]; then
-            checkpointTime=$((SECONDS - start_time))
-            checkpointFound="true"
-            echo "Checkpoint went through. Time taken: $(printf '%02dm:%02ds\n' $((checkpointTime % 3600 / 60)) $((checkpointTime % 60)))"
-        fi
-    fi
-
-    if [ "$stateSyncFound" == "true" ] && [ "$checkpointFound" == "true" ]; then
-        break
-    fi
-
+	echo "Current event count: $CURRENT_EVENT_COUNT (expected: $EXPECTED_EVENT_COUNT)"
+	sleep 5
 done
-echo "Both state sync and checkpoint went through. All tests have passed!"
-echo "Time taken for state sync: $(printf '%02dm:%02ds\n' $((stateSyncTime % 3600 / 60)) $((stateSyncTime % 60)))"
-echo "Time taken for checkpoint: $(printf '%02dm:%02ds\n' $((checkpointTime % 3600 / 60)) $((checkpointTime % 60)))"
+
+# Now check BOR balance bumped by exactly 100 MATIC.
+EXPECTED_BOR_BALANCE=$((INITIAL_BOR_BALANCE + 100))
+echo "Waiting for BOR balance to reach exactly: $EXPECTED_BOR_BALANCE"
+
+while true; do
+	CURRENT_BOR_BALANCE=$(docker exec bor0 bash -c "bor attach /var/lib/bor/data/bor.ipc --exec \"Math.round(web3.fromWei(eth.getBalance(eth.accounts[0]), 'ether'))\"")
+
+	if ! [[ $CURRENT_BOR_BALANCE =~ ^[0-9]+$ ]]; then
+		echo "❌ Error reading BOR balance (got: $CURRENT_BOR_BALANCE)"
+		exit 1
+	fi
+
+	if [ "$CURRENT_BOR_BALANCE" -eq "$EXPECTED_BOR_BALANCE" ]; then
+		echo "✅ BOR balance updated correctly: $CURRENT_BOR_BALANCE"
+		break
+	else
+		echo "Current BOR balance: $CURRENT_BOR_BALANCE (expected: $EXPECTED_BOR_BALANCE)"
+	fi
+
+	sleep 5
+done
+
+echo "🎉 All state sync tests passed — Heimdall clerk events and BOR balance look good!"
+
+echo "Starting checkpoint test…"
+while true; do
+	checkpointID=$(curl -s localhost:1317/checkpoints/latest | jq -r '.checkpoint.id' || echo "null")
+	if [ "$checkpointID" != "null" ]; then
+		echo "✅ Checkpoint created! ID: $checkpointID"
+		break
+	else
+		echo "Current checkpoint: none (polling…)"
+		sleep 5
+	fi
+done
+
+echo "🎉 Checkpoint test passed — Heimdall checkpoint looks good!"


### PR DESCRIPTION
# Description

This update overhauls our end-to-end “smoke” test suite and Anvil setup so that we can confidently verify that Heimdall’s state-sync API handles paginated results correctly.

- Automating 100 deposits and waiting for exactly 100 new events in /clerk/event-records/count, we confirm that the “record-count” endpoint and its pagination under load always surface the full range of data.